### PR TITLE
Reduce unsupported attributes output (fixes #39)

### DIFF
--- a/src/main/java/org/fife/rsta/ac/java/classreader/ClassFile.java
+++ b/src/main/java/org/fife/rsta/ac/java/classreader/ClassFile.java
@@ -587,7 +587,7 @@ public class ClassFile implements AccessFlags {
 		// TODO: Handle other useful Attribute types, if any.
 
 		else { // An unknown/unsupported attribute.
-			System.out.println("Unsupported class attribute: "+  attrName);
+			debugPrint("Unsupported class attribute: "+  attrName);
 			ai = AttributeInfo.readUnsupportedAttribute(this, in, attrName,
 					attributeLength);
 		}


### PR DESCRIPTION
Loading jar files with many scala classes results in many many many lines of
```
Unsupported class attribute: ScalaInlineInfo
Unsupported class attribute: ScalaSig
``` 

This PR simply use the `debugPrint` method instead of `System.out.println` to reduce the output in production.