### PR TITLE
Use bulk mode in class name completion (fixes #40)

### DIFF
--- a/src/main/java/org/fife/rsta/ac/java/JarReader.java
+++ b/src/main/java/org/fife/rsta/ac/java/JarReader.java
@@ -127,8 +127,20 @@ class JarReader {
 	public List<ClassFile> getClassesWithNamesStartingWith(String prefix) {
 		List<ClassFile> res = new ArrayList<ClassFile>();
 		String currentPkg = ""; // Don't use null; we're appending to it
-		packageMap.getClassesWithNamesStartingWith(info, prefix, currentPkg,
-				res);
+
+		try {
+			info.bulkClassFileCreationStart();
+
+			try {
+				packageMap.getClassesWithNamesStartingWith(info, prefix, currentPkg, res);
+			} finally {
+				info.bulkClassFileCreationEnd();
+			}
+
+		} catch (final IOException ioe) {
+			ioe.printStackTrace();
+		}
+
 		return res;
 	}
 

--- a/src/main/java/org/fife/rsta/ac/java/PackageMapNode.java
+++ b/src/main/java/org/fife/rsta/ac/java/PackageMapNode.java
@@ -359,7 +359,7 @@ public class PackageMapNode {
 				if (cf==null) {
 					String fqClassName = currentPkg + className + ".class";
 					try {
-						cf = info.createClassFile(fqClassName);
+						cf = info.createClassFileBulk(fqClassName);
 						cfEntry.setValue(cf); // Update the map
 					} catch (IOException ioe) {
 						ioe.printStackTrace();


### PR DESCRIPTION
Running Java class name completion on large jar files (e.g. Spark, 35MB, 22K Classes) takes long (e.g. Class names with an _A_ takes ~180 Seconds).

Open the jar and seeking to the class on each class takes very long:
https://github.com/bobbylight/RSTALanguageSupport/blob/c4ff0a2d6cc12e0b7f39e814c9a1dee2db5b5dca/src/main/java/org/fife/rsta/ac/java/buildpath/JarLibraryInfo.java#L96-L104

Instead of open the jar on every class, use the bulk API on class name completion. This reduce the time in the example above to ~3s.