### PR TITLE
Support loaded classes adhoc in jvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ javadoc
 *.java~
 build
 .gradle
+/.idea/
+/languagesupport.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-['java', 'distribution', 'maven', 'signing'].each { apply plugin: it }
+['java', 'distribution', 'maven', 'maven-publish', 'signing'].each { apply plugin: it }
 
 assert org.gradle.api.JavaVersion.current().isJava6Compatible()
 if (org.gradle.api.JavaVersion.current().isJava8Compatible()) {
@@ -15,6 +15,7 @@ archivesBaseName = 'languagesupport'
 dependencies {
 	compile group: 'org.mozilla', name: 'rhino', version: '1.7.6'
 	testCompile group: 'junit', name: 'junit', version: '4.11'
+	compile 'com.fifesoft:autocomplete:2.6.1'
 }
 
 // Regenerate local gradlew
@@ -218,3 +219,14 @@ uploadArchives {
 		}
 	}
 }
+
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			from components.java
+			artifact sourceJar { classifier "sources" }
+		}
+	}
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
 javaVersion=1.6
-version=2.6.1-SNAPSHOT
+version=2.6.2-SNAPSHOT
 

--- a/src/main/java/org/fife/rsta/ac/java/JarManager.java
+++ b/src/main/java/org/fife/rsta/ac/java/JarManager.java
@@ -10,8 +10,10 @@
  */
 package org.fife.rsta.ac.java;
 
+import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -277,6 +279,22 @@ TODO: Verify me!!!
 							result = new ArrayList<ClassFile>(1); // Usually small
 						}
 						result.add(entry);
+					} else {
+						try {
+							Class<?> classByName =
+									Class.forName(qualified);
+
+							InputStream classAsStream = classByName.getResourceAsStream("/" + qualified.replace(".", "/") + ".class");
+							if (result==null) {
+								result = new ArrayList<ClassFile>(1); // Usually small
+							}
+							result.add(new ClassFile(new DataInputStream(classAsStream)));
+						} catch (ClassNotFoundException e) {
+							e.printStackTrace();
+						} catch (IOException e) {
+							e.printStackTrace();
+						}
+						//System.err.println("ERROR: Class not found! - " + name2);
 					}
 
 				}
@@ -294,7 +312,21 @@ TODO: Verify me!!!
 							result.add(entry);
 						}
 						else {
-							System.err.println("ERROR: Class not found! - " + name2);
+							try {
+								Class<?> classByName =
+										Class.forName(name2);
+
+								InputStream classAsStream = classByName.getResourceAsStream("/" + name2.replace(".", "/") + ".class");
+								if (result==null) {
+									result = new ArrayList<ClassFile>(1); // Usually small
+								}
+								result.add(new ClassFile(new DataInputStream(classAsStream)));
+							} catch (ClassNotFoundException e) {
+								e.printStackTrace();
+							} catch (IOException e) {
+								e.printStackTrace();
+							}
+							//System.err.println("ERROR: Class not found! - " + name2);
 						}
 					}
 				}


### PR DESCRIPTION
Hey guys,

with this change, currently loaded classes are supported by autocomplete. In case the JarManager does not know a class, it tries to get the ClassFile from the classes which are currently loaded in the JVM. 
In Fijis script editor, we are working with hundreds of JAR files. Loading all classes in all of them would take a long time. Instead, ad-hoc loading one particular class from a JAR file appears beneficial for performance.

If you want to try this change, publish it to your local maven repository and execute the main method (from your IDE):
https://github.com/haesleinhuepf/script-editor/blob/playing_wth_java_autocomplete/src/main/java/org/scijava/ui/swing/script/demo/Demo.java#L16

And enter code like this in the editor window:
```
import ij.plugin.PlugIn;
import ij.*;

public class Bare_PlugIn implements PlugIn {
	@Override
	public void run(String arg) {
		IJ.
	}
}
```

Then, open the auto-complete pulldown behind `IJ.` and you will see static members even though the JarManager doesn't know about IJ.jar.

Please let me know what you think about this!

Cheers,
Robert


