### PR TITLE
Scan functions inside of initializers or function calls

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
@@ -533,6 +533,8 @@ public class JavaScriptAstParser extends JavaScriptParser {
 			List<VariableInitializer> vars = varDec.getVariables();
 			for (VariableInitializer var : vars) {
 				extractVariableFromNode(var, block, offset);
+                // we still need to process the initializer code, it may contain other functions
+                iterateNode(var.getInitializer(), set, entered, block, offset);
 			}
 		}
 	}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
@@ -176,7 +176,6 @@ public class JavaScriptAstParser extends JavaScriptParser {
 				case Token.NAME:
 				case Token.CATCH:
 				case Token.ERROR:
-				case Token.RETURN:
 				case Token.NEW:
 				case Token.GETPROP:
 					// xml support -- ignore these
@@ -185,6 +184,10 @@ public class JavaScriptAstParser extends JavaScriptParser {
 					break;
                 case Token.CALL:
                     processCallStatement(child, block, set, entered,
+                            offset);
+                    break;
+                case Token.RETURN:
+                    processReturnStatement(child, block, set, entered,
                             offset);
                     break;
 				case Token.EXPR_RESULT:
@@ -217,6 +220,11 @@ public class JavaScriptAstParser extends JavaScriptParser {
         }
     }
 
+    private void processReturnStatement(Node child, CodeBlock block,
+                                      Set<Completion> set, String entered, int offset) {
+        ReturnStatement returnStatement = (ReturnStatement) child;
+        iterateNode(returnStatement.getReturnValue(), set, entered, block, offset);
+    }
 
 	private void reassignVariable(AstNode assign, CodeBlock block,
 			int locationOffSet) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
@@ -34,6 +34,7 @@ import org.mozilla.javascript.ast.IfStatement;
 import org.mozilla.javascript.ast.InfixExpression;
 import org.mozilla.javascript.ast.Name;
 import org.mozilla.javascript.ast.NodeVisitor;
+import org.mozilla.javascript.ast.ParenthesizedExpression;
 import org.mozilla.javascript.ast.ReturnStatement;
 import org.mozilla.javascript.ast.SwitchCase;
 import org.mozilla.javascript.ast.SwitchStatement;
@@ -194,6 +195,10 @@ public class JavaScriptAstParser extends JavaScriptParser {
 					processExpressionStatement(child, block, set, entered,
 							offset);
 					break;
+                case Token.LP:
+                    processParenthesizedExpression(child, block, set, entered,
+                            offset);
+                    break;
 				default:
 					Logger.log("Unhandled: " + child.getClass() + " (\""
 							+ child + "\":" + child.getLineno());
@@ -212,9 +217,18 @@ public class JavaScriptAstParser extends JavaScriptParser {
 		iterateNode(expNode, set, entered, block, offset);
 	}
 
+    private void processParenthesizedExpression(Node child, CodeBlock block,
+            Set<Completion> set, String entered, int offset) {
+        ParenthesizedExpression exp = (ParenthesizedExpression) child;
+
+        AstNode expNode = exp.getExpression();
+        iterateNode(expNode, set, entered, block, offset);
+    }
+
     private void processCallStatement(Node child, CodeBlock block,
             Set<Completion> set, String entered, int offset) {
         FunctionCall functionCall = (FunctionCall) child;
+        iterateNode(functionCall.getTarget(), set, entered, block, offset);
         for (AstNode arg: functionCall.getArguments()) {
             iterateNode(arg, set, entered, block, offset);
         }

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptAstParser.java
@@ -29,6 +29,7 @@ import org.mozilla.javascript.ast.ExpressionStatement;
 import org.mozilla.javascript.ast.ForInLoop;
 import org.mozilla.javascript.ast.ForLoop;
 import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.ast.FunctionCall;
 import org.mozilla.javascript.ast.IfStatement;
 import org.mozilla.javascript.ast.InfixExpression;
 import org.mozilla.javascript.ast.Name;
@@ -171,7 +172,6 @@ public class JavaScriptAstParser extends JavaScriptParser {
 				// ignore
 				case Token.BREAK:
 				case Token.CONTINUE:
-				case Token.CALL:
 				case Token.EMPTY:
 				case Token.NAME:
 				case Token.CATCH:
@@ -183,6 +183,10 @@ public class JavaScriptAstParser extends JavaScriptParser {
 				case Token.DEFAULTNAMESPACE:
 				case Token.XMLATTR:
 					break;
+                case Token.CALL:
+                    processCallStatement(child, block, set, entered,
+                            offset);
+                    break;
 				case Token.EXPR_RESULT:
 					processExpressionStatement(child, block, set, entered,
 							offset);
@@ -204,6 +208,14 @@ public class JavaScriptAstParser extends JavaScriptParser {
 		AstNode expNode = exp.getExpression();
 		iterateNode(expNode, set, entered, block, offset);
 	}
+
+    private void processCallStatement(Node child, CodeBlock block,
+            Set<Completion> set, String entered, int offset) {
+        FunctionCall functionCall = (FunctionCall) child;
+        for (AstNode arg: functionCall.getArguments()) {
+            iterateNode(arg, set, entered, block, offset);
+        }
+    }
 
 
 	private void reassignVariable(AstNode assign, CodeBlock block,


### PR DESCRIPTION
Functions inside of initializers or function calls (and maybe in other positions as well) are currently ignored.

Such functions, passed as callbacks, are common is some JS enviroments.

First commit adds handling  for functions defined in variable initializers, like this:

```js
var f = function (s) {
  var something = s.compute()
};
```

I hope to be able to handle at least following scenario as well:

```js
call(function (s) {
  var something = s.compute()
});
```