### PR TITLE
Build with Java 17, require Java 11 to run

### DIFF
--- a/RSTALanguageSupport/build.gradle
+++ b/RSTALanguageSupport/build.gradle
@@ -4,12 +4,10 @@ plugins {
 
 ['java', 'distribution', 'maven-publish', 'signing'].each { apply plugin: it }
 
-assert JavaVersion.current().isJava8Compatible()
-
 dependencies {
     api 'com.fifesoft:rsyntaxtextarea:3.3.0'
     api 'com.fifesoft:autocomplete:3.3.0'
-    implementation 'org.mozilla:rhino:1.7.14'
+    implementation 'org.mozilla:rhino-all:1.8.0'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/Actions.java
+++ b/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/Actions.java
@@ -88,7 +88,7 @@ interface Actions {
 			this.demo = demo;
 			putValue(NAME, "Open...");
 			putValue(MNEMONIC_KEY, (int)'O');
-			int mods = demo.getToolkit().getMenuShortcutKeyMask();
+			int mods = demo.getToolkit().getMenuShortcutKeyMaskEx();
 			KeyStroke ks = KeyStroke.getKeyStroke(KeyEvent.VK_O, mods);
 			putValue(ACCELERATOR_KEY, ks);
 		}

--- a/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/DemoRootPane.java
+++ b/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/DemoRootPane.java
@@ -77,7 +77,10 @@ class DemoRootPane extends JRootPane implements HyperlinkListener,
 		// changes to the build path.
 		try {
 			jls.getJarManager().addCurrentJreClassFileSource();
-		} catch (IOException ioe) {
+		} catch (IllegalArgumentException | IOException ioe) {
+			JOptionPane.showMessageDialog(this,
+					"Error adding JRE class file source: " + ioe.getMessage(),
+					"Error", JOptionPane.ERROR_MESSAGE);
 			ioe.printStackTrace();
 		}
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,12 @@
 //    id 'com.github.spotbugs' version '5.0.12'
 //}
 
+// We require building with JDK 17 or later. Built artifact compatibility
+// is controlled by javaLanguageVersion
+assert JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17)
+
 group = 'com.fifesoft'
-// NOTE: Local Java 8:  /Library/Java/JavaVirtualMachines/jdk1.8.0_191.jdk/Contents/Home
+// NOTE: Local Java 17: /Library/Java/JavaVirtualMachines/jdk-17.0.13+11/Contents/Home
 
 allprojects {
 
@@ -57,8 +61,7 @@ subprojects {
 //    }
 
     compileJava {
-        sourceCompatibility = javaVersion.toString()
-        targetCompatibility = javaVersion.toString()
+        options.release = Integer.parseInt(javaLanguageVersion)
         options.debug = true
         options.debugOptions.debugLevel = 'source,vars,lines'
         options.compilerArgs << '-Xlint:deprecation' << '-Xlint:unchecked'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Note that Maven- and signing-related properties are in <maven-home>/gradle.properties
-javaVersion=1.8
-version=3.3.1-SNAPSHOT
+javaLanguageVersion=11
+version=3.4.0-SNAPSHOT
 
 # Ugh, see https://github.com/gradle/gradle/issues/11308
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Like it says on the tin. Bump required JRE to build to Java 17 (hand being forced by gradle), and bump minimum runtime JRE to 11. It should be Java 8 but the `runtime` JDK argument seems to have issues with finding some JDK components now that they are modularized, such as `org.w3c.dom`. I don't think it's worth trying to fix; instead I think it's better to just make the minimum requirement be Java 11, especially considering that version is 7 years old now.