### PR TITLE
Fix Java 11 compiler warnings

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/GoToMemberAction.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/GoToMemberAction.java
@@ -87,7 +87,7 @@ public class GoToMemberAction extends TextAction {
 	private AbstractSourceTree createTree() {
 		AbstractSourceTree tree = null;
 		try {
-			tree = (AbstractSourceTree)outlineTreeClass.newInstance();
+			tree = (AbstractSourceTree)outlineTreeClass.getDeclaredConstructor().newInstance();
 			tree.setSorted(true);
 		} catch (RuntimeException re) { // FindBugs
 			throw re;

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/LanguageSupportFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/LanguageSupportFactory.java
@@ -143,7 +143,7 @@ public final class LanguageSupportFactory implements PropertyChangeListener {
 			if (supportClazz!=null) {
 				try {
 					Class<?> clazz = Class.forName(supportClazz);
-					support = (LanguageSupport)clazz.newInstance();
+					support = (LanguageSupport)clazz.getDeclaredConstructor().newInstance();
 				} catch (RuntimeException re) { // FindBugs
 					throw re;
 				} catch (Exception e) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JavaLanguageSupport.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JavaLanguageSupport.java
@@ -176,7 +176,7 @@ public class JavaLanguageSupport extends AbstractLanguageSupport {
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, c|shift), "GoToType");
@@ -221,7 +221,7 @@ public class JavaLanguageSupport extends AbstractLanguageSupport {
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.remove(KeyStroke.getKeyStroke(KeyEvent.VK_O, c|shift));

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptLanguageSupport.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptLanguageSupport.java
@@ -314,7 +314,7 @@ return DEFAULT;
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, c | shift), "GoToType");
@@ -514,7 +514,7 @@ return DEFAULT;
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.remove(KeyStroke.getKeyStroke(KeyEvent.VK_O, c | shift));

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
@@ -123,7 +123,7 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 	@Override
 	public List<Completion> getCompletionsAt(JTextComponent tc, Point p) {
 
-		int offset = tc.viewToModel(p);
+		int offset = tc.viewToModel2D(p);
 		if (offset<0 || offset>=tc.getDocument().getLength()) {
 			lastCompletionsAtText = null;
 			return lastParameterizedCompletionsAt = null;

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/TypeDeclarationFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/TypeDeclarationFactory.java
@@ -46,7 +46,7 @@ public class TypeDeclarationFactory {
 			ecmaVersion = ecmaVersion == null ? getDefaultECMAVersion() : ecmaVersion;
 			//try to instantiate classes
 			Class<?> ecmaClass = TypeDeclarationFactory.class.getClassLoader().loadClass(ecmaVersion);
-		 	ecma = (TypeDeclarations) ecmaClass.newInstance();
+		 	ecma = (TypeDeclarations) ecmaClass.getDeclaredConstructor().newInstance();
 		}
 		catch(Exception e)
 		{

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/xml/XmlLanguageSupport.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/xml/XmlLanguageSupport.java
@@ -170,7 +170,7 @@ public class XmlLanguageSupport extends AbstractMarkupLanguageSupport {
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, c|shift), "GoToType");
@@ -227,7 +227,7 @@ public class XmlLanguageSupport extends AbstractMarkupLanguageSupport {
 
 		InputMap im = textArea.getInputMap();
 		ActionMap am = textArea.getActionMap();
-		int c = textArea.getToolkit().getMenuShortcutKeyMask();
+		int c = textArea.getToolkit().getMenuShortcutKeyMaskEx();
 		int shift = InputEvent.SHIFT_DOWN_MASK;
 
 		im.remove(KeyStroke.getKeyStroke(KeyEvent.VK_O, c | shift));


### PR DESCRIPTION
Fix compiler warnings added in Java 11+ (i.e. warnings around deprecated AWT/Swing APIs).