### PR TITLE
Fix #68: MethodInfo.getReturnTypeString() breaks if first called with false

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/MethodInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/MethodInfo.java
@@ -69,7 +69,7 @@ public class MethodInfo extends MemberInfo implements AccessFlags {
 	/**
 	 * Cached return type.
 	 */
-	private String returnType;
+	private String fullyQualifiedReturnType;
 
 	/**
 	 * Cached string representing the name and parameters for this method.
@@ -138,7 +138,7 @@ public class MethodInfo extends MemberInfo implements AccessFlags {
 	 */
 	void clearParamTypeInfo() {
 		paramTypes = null;
-		returnType = null;
+		fullyQualifiedReturnType = null;
 	}
 
 
@@ -437,18 +437,18 @@ public class MethodInfo extends MemberInfo implements AccessFlags {
 	 * @return The return type of this method.
 	 */
 	public String getReturnTypeString(boolean fullyQualified) {
-		if (returnType==null) {
-			returnType = getReturnTypeStringFromTypeSignature(fullyQualified);
-			if (returnType==null) {
-				returnType = getReturnTypeStringFromDescriptor(fullyQualified);
+		if (fullyQualifiedReturnType == null) {
+			fullyQualifiedReturnType = getReturnTypeStringFromTypeSignature(true);
+			if (fullyQualifiedReturnType == null) {
+				fullyQualifiedReturnType = getReturnTypeStringFromDescriptor(true);
 			}
 		}
 		if (!fullyQualified) {
-			if (returnType != null && returnType.contains(".")) {
-				return returnType.substring(returnType.lastIndexOf(".") +1);
+			if (fullyQualifiedReturnType != null && fullyQualifiedReturnType.contains(".")) {
+				return fullyQualifiedReturnType.substring(fullyQualifiedReturnType.lastIndexOf(".") +1);
 			}
 		}
-		return returnType;
+		return fullyQualifiedReturnType;
 	}
 
 

--- a/RSTALanguageSupport/src/test/java/org/fife/rsta/ac/java/classreader/MethodInfoTest.java
+++ b/RSTALanguageSupport/src/test/java/org/fife/rsta/ac/java/classreader/MethodInfoTest.java
@@ -1,0 +1,58 @@
+/*
+ * This library is distributed under a modified BSD license.  See the included
+ * LICENSE.md file for details.
+ */
+package org.fife.rsta.ac.java.classreader;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * Unit tests for the {@code MethodInfo} class.
+ */
+class MethodInfoTest {
+
+	@Test
+	void testGetReturnTypeString_fullyQualified_true() {
+		// A method taking a String and an int as inputs that returns an Object
+		String methodDescriptor = "(Ljava/lang/String;I)Ljava/lang/Object;";
+
+		ClassFile cf = Mockito.mock(ClassFile.class);
+		doReturn(methodDescriptor).when(cf).getUtf8ValueFromConstantPool(anyInt());
+
+		MethodInfo mi = new MethodInfo(cf, 0, 0, 0);
+		assertEquals("java.lang.Object", mi.getReturnTypeString(true));
+	}
+
+	@Test
+	void testGetReturnTypeString_fullyQualified_false() {
+		// A method taking a String and an int as inputs that returns an Object
+		String methodDescriptor = "(Ljava/lang/String;I)Ljava/lang/Object;";
+
+		ClassFile cf = Mockito.mock(ClassFile.class);
+		doReturn(methodDescriptor).when(cf).getUtf8ValueFromConstantPool(anyInt());
+
+		MethodInfo mi = new MethodInfo(cf, 0, 0, 0);
+		assertEquals("Object", mi.getReturnTypeString(false));
+	}
+
+	// Verifies fix for https://github.com/bobbylight/RSTALanguageSupport/issues/68
+	@Test
+	void testGetReturnTypeString_fullyQualified_falseThenTrue() {
+		// A method taking a String and an int as inputs that returns an Object
+		String methodDescriptor = "(Ljava/lang/String;I)Ljava/lang/Object;";
+
+		ClassFile cf = Mockito.mock(ClassFile.class);
+		doReturn(methodDescriptor).when(cf).getUtf8ValueFromConstantPool(anyInt());
+
+		MethodInfo mi = new MethodInfo(cf, 0, 0, 0);
+
+		// First call returns unqualified, second returns qualified
+		assertEquals("Object", mi.getReturnTypeString(false));
+		assertEquals("java.lang.Object", mi.getReturnTypeString(true));
+	}
+}

--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ subprojects {
         testImplementation platform('org.junit:junit-bom:5.13.1')
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testImplementation 'org.mockito:mockito-core:5.15.2'
     }
 
     compileJava {


### PR DESCRIPTION
Fix for #68. `MethodInfo.getReturnTypeString()` should always cache the fully qualified return type so that subsequent calls can return both the qualified and unqualified versions.

Added unit tests to verify the fix.