### PR TITLE
Use bulk mode in class name completion

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarReader.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarReader.java
@@ -127,8 +127,16 @@ class JarReader {
 	public List<ClassFile> getClassesWithNamesStartingWith(String prefix) {
 		List<ClassFile> res = new ArrayList<>();
 		String currentPkg = ""; // Don't use null; we're appending to it
-		packageMap.getClassesWithNamesStartingWith(info, prefix, currentPkg,
-				res);
+		try {
+			info.bulkClassFileCreationStart();
+			try {
+				packageMap.getClassesWithNamesStartingWith(info, prefix, currentPkg, res);
+			} finally {
+				info.bulkClassFileCreationEnd();
+			}
+		} catch (final IOException ioe) {
+			ioe.printStackTrace();
+		}
 		return res;
 	}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/PackageMapNode.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/PackageMapNode.java
@@ -356,7 +356,10 @@ public class PackageMapNode {
 
 	/**
 	 * Method used to recursively scan our package map for classes whose names
-	 * start with a given prefix, ignoring case.
+	 * start with a given prefix, ignoring case.<p>
+	 *
+	 * Note: This method assumes you are fetching class files in bulk from the
+	 * {@code LibraryInfo} instance.
 	 *
 	 * @param prefix The prefix that the unqualified class names must match
 	 *        (ignoring case).
@@ -387,7 +390,7 @@ public class PackageMapNode {
 				if (cf==null) {
 					String fqClassName = currentPkg + className + ".class";
 					try {
-						cf = info.createClassFile(fqClassName);
+						cf = info.createClassFileBulk(fqClassName);
 						cfEntry.setValue(cf); // Update the map
 					} catch (IOException ioe) {
 						ioe.printStackTrace();

--- a/RSTALanguageSupport/src/test/java/org/fife/rsta/ac/java/JarReaderTest.java
+++ b/RSTALanguageSupport/src/test/java/org/fife/rsta/ac/java/JarReaderTest.java
@@ -46,7 +46,7 @@ public class JarReaderTest {
         LibraryInfo mockInfo = Mockito.mock(LibraryInfo.class);
         doReturn(System.currentTimeMillis()).when(mockInfo).getLastModified();
         doReturn(packageMap).when(mockInfo).createPackageMap();
-        when(mockInfo.createClassFile(anyString())).thenAnswer(input -> {
+        when(mockInfo.createClassFileBulk(anyString())).thenAnswer(input -> {
             ClassFile cf = Mockito.mock(ClassFile.class);
             doReturn(input.getArgument(0)).when(cf).getClassName(anyBoolean());
             return cf;


### PR DESCRIPTION
Replacement for long-abandoned #42. This is coming in way too late. Kudos to @derSascha for the fix!

This updates `JarLibraryInfo` to use the bulk API when getting completion suggestions for Java class names. This in turn is much faster the first time this action is performed, since we'll open the Jar for reading just once to fetch all matching classes, not _n_ times.