### PR TITLE
Fix #33: Remove System.(out|err).println calls

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/IOUtil.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/IOUtil.java
@@ -60,9 +60,9 @@ public final class IOUtil {
 
 
 	/**
-	 * Returns the value of an environment variable.  This method is here so
-	 * we don't get an exception when calling <tt>System.getenv()</tt> in Java
-	 * 1.4 (which we support).
+	 * Returns the value of an environment variable. This method is a holdover
+	 * from when we supported Java 1.4 and will be removed in the next major
+	 * release. Prefer calling {@code System.getenv(String)} directly.
 	 *
 	 * @param var The environment variable.
 	 * @return The value of the variable, or <code>null</code> if it is not
@@ -153,19 +153,6 @@ public final class IOUtil {
 
 		return rc;
 
-	}
-
-
-	/**
-	 * Utility testing method.
-	 *
-	 * @param args Command line arguments.
-	 */
-	public static void main(String[] args) {
-        for (String arg : args) {
-            String value = IOUtil.getEnvSafely(arg);
-            System.out.println(arg + "=" + value);
-        }
 	}
 
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarManager.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarManager.java
@@ -12,6 +12,7 @@ package org.fife.rsta.ac.java;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -34,6 +35,9 @@ import org.fife.ui.autocomplete.CompletionProvider;
  * @version 1.0
  */
 public class JarManager {
+
+	private static final Logger LOG =
+		System.getLogger(JarManager.class.getName());
 
 	/**
 	 * Locations of class files to get completions from.
@@ -297,7 +301,8 @@ public class JarManager {
 							result.add(entry);
 						}
 						else {
-							System.err.println("ERROR: Class not found! - " + name2);
+							LOG.log(System.Logger.Level.ERROR,
+								"Class not found! - " + name2);
 						}
 					}
 				}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarReader.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JarReader.java
@@ -11,6 +11,7 @@
 package org.fife.rsta.ac.java;
 
 import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -32,6 +33,9 @@ import org.fife.ui.autocomplete.CompletionProvider;
  * @version 1.0
  */
 class JarReader {
+
+	private static final Logger LOG =
+		System.getLogger(JarReader.class.getName());
 
 	/**
 	 * Information about the jar or directory we're reading classes from.
@@ -86,7 +90,8 @@ class JarReader {
 		if (newLastModified!=0 && newLastModified!=lastModified) {
 			int count;
 			count = packageMap.clearClassFiles();
-			System.out.println("DEBUG: Cleared " + count + " cached ClassFiles");
+			LOG.log(System.Logger.Level.DEBUG,
+				"Cleared " + count + " cached ClassFiles");
 			lastModified = newLastModified;
 		}
 	}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JavadocUrlHandler.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/JavadocUrlHandler.java
@@ -10,6 +10,7 @@
  */
 package org.fife.rsta.ac.java;
 
+import java.lang.System.Logger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -39,6 +40,8 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
  */
 public class JavadocUrlHandler implements ExternalURLHandler {
 
+	private static final Logger LOG =
+		System.getLogger(JavadocUrlHandler.class.getName());
 
 	/**
 	 * Returns the parent package <code>backupCount</code> levels up from
@@ -124,7 +127,7 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 			clazz = mc.getEnclosingClassName(true);
 		}
 		else {
-			System.err.println("Can't determine class from completion type: " +
+			logError("Can't determine class from completion type: " +
 					c.getClass() + " (" + c + ") - href: " + desc);
 		}
 
@@ -158,7 +161,7 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 			}
 		}
 		else {
-			System.err.println("Can't determine package from completion type: " +
+			logError("Can't determine package from completion type: " +
 					c.getClass() + " (" + c + ") - href: " + desc);
 		}
 
@@ -186,6 +189,10 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 	}
 
 
+	private static void logError(String text) {
+		LOG.log(System.Logger.Level.ERROR, text);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -211,7 +218,6 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 		// Class should be in the same package as the one we're currently
 		// viewing.  Example:  java.lang.String class documentation
 		String desc = e.getDescription();
-		//System.out.println(desc);
 		if (desc!=null) {
 
 			if (isRelativeUrl(desc)) {
@@ -281,7 +287,7 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 					}
 					else {
 						UIManager.getLookAndFeel().provideErrorFeedback(null);
-						System.err.println("Unknown class: " + clazz);
+						logError("Unknown class: " + clazz);
 					}
 				}
 
@@ -340,7 +346,7 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 							if (miList!=null && miList.size()>0) {
 								if (miList.size()>1) {
 									// TODO: Pick correct overload based on args
-									System.err.println("Multiple overload support not yet implemented");
+									logError("Multiple overload support not yet implemented");
 								}
 								else {
 									MethodInfo mi = miList.get(0);
@@ -356,7 +362,7 @@ public class JavadocUrlHandler implements ExternalURLHandler {
 					}
 					else {
 						UIManager.getLookAndFeel().provideErrorFeedback(null);
-						System.err.println("Unknown class: " + clazz +
+						logError("Unknown class: " + clazz +
 								" (href: " + desc + ")");
 					}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/SourceCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/SourceCompletionProvider.java
@@ -14,6 +14,7 @@ import java.awt.Cursor;
 import java.awt.Point;
 import java.io.File;
 import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -69,6 +70,9 @@ import org.fife.ui.rsyntaxtextarea.Token;
  * @version 1.0
  */
 class SourceCompletionProvider extends DefaultCompletionProvider {
+
+	private static final Logger LOG =
+		System.getLogger(SourceCompletionProvider.class.getName());
 
 	/**
 	 * The parent completion provider.
@@ -423,7 +427,7 @@ class SourceCompletionProvider extends DefaultCompletionProvider {
 			RSyntaxTextArea textArea = (RSyntaxTextArea)comp;
 			RSyntaxDocument doc = (RSyntaxDocument)textArea.getDocument();
 			try {
-				//System.out.println(doc.charAt(offs) + ", " + doc.charAt(offs+1));
+				//log(doc.charAt(offs) + ", " + doc.charAt(offs+1));
 				if (doc.charAt(offs)=='"' && doc.charAt(offs+1)=='.') {
 					int curLine = textArea.getLineOfOffset(offs);
 					Token list = textArea.getTokenListForLine(curLine);
@@ -434,9 +438,6 @@ class SourceCompletionProvider extends DefaultCompletionProvider {
 						addCompletionsForExtendedClass(set, cu, cf,
 													cu.getPackageName(), null);
 						stringLiteralMember = true;
-					}
-					else {
-						System.out.println(prevToken);
 					}
 				}
 			} catch (BadLocationException ble) { // Never happens
@@ -541,7 +542,7 @@ class SourceCompletionProvider extends DefaultCompletionProvider {
 			//long startTime = System.currentTimeMillis();
 			jarManager.addCompletions(this, text, set);
 			//long time = System.currentTimeMillis() - startTime;
-			//System.out.println("jar completions loaded in: " + time);
+			//log("jar completions loaded in: " + time);
 
 			// Loop through all types declared in this source, and provide
 			// completions depending on in what type/method/etc. the caret's in.
@@ -599,7 +600,7 @@ class SourceCompletionProvider extends DefaultCompletionProvider {
 
 
 
-public SourceLocation  getSourceLocForClass(String className) {
+public SourceLocation getSourceLocForClass(String className) {
 	return jarManager.getSourceLocForClass(className);
 }
 
@@ -689,7 +690,7 @@ public SourceLocation  getSourceLocForClass(String className) {
 		}
 
 		//long time = System.currentTimeMillis() - startTime;
-		//System.out.println("methods/fields/localvars loaded in: " + time);
+		//log("methods/fields/localvars loaded in: " + time);
 
 	}
 
@@ -786,7 +787,7 @@ public SourceLocation  getSourceLocForClass(String className) {
 						addCompletionsForExtendedClass(retVal, cu, cf, pkg, null);
 					}
 					else {
-						System.out.println("[DEBUG]: Couldn't find ClassFile for: " + superClassName);
+						log("[DEBUG]: Couldn't find ClassFile for: " + superClassName);
 					}
 				}
 			}
@@ -826,13 +827,13 @@ public SourceLocation  getSourceLocForClass(String className) {
 		// TODO: Remove this restriction.
 		int dot = prefix.indexOf('.');
 		if (dot>-1) {
-			System.out.println("[DEBUG]: Qualified non-this completions currently only go 1 level deep");
+			log("[DEBUG]: Qualified non-this completions currently only go 1 level deep");
 			return;
 		}
 
 		// TODO: Remove this restriction.
 		else if (!prefix.matches("[A-Za-z_][A-Za-z0-9_\\$]*")) {
-			System.out.println("[DEBUG]: Only identifier non-this completions are currently supported");
+			log("[DEBUG]: Only identifier non-this completions are currently supported");
 			return;
 		}
 
@@ -849,7 +850,7 @@ public SourceLocation  getSourceLocForClass(String className) {
 				Field field = (Field)m;
 
 				if (field.getName().equals(prefix)) {
-					//System.out.println("FOUND: " + prefix + " (" + pkg + ")");
+					//log("FOUND: " + prefix + " (" + pkg + ")");
 					Type type = field.getType();
 					if (type.isArray()) {
 						ClassFile cf = getClassFileFor(cu, "java.lang.Object");
@@ -870,7 +871,7 @@ public SourceLocation  getSourceLocForClass(String className) {
 							for (int i=0; i<cf.getImplementedInterfaceCount(); i++) {
 								String inter = cf.getImplementedInterfaceName(i, true);
 								cf = getClassFileFor(cu, inter);
-								System.out.println(cf);
+								log(cf.toString());
 							}
 						}
 					}
@@ -1026,8 +1027,13 @@ public SourceLocation  getSourceLocForClass(String className) {
 		//Collections.sort(completions);
 
 		//long time = System.currentTimeMillis() - startTime;
-		//System.out.println("imports loaded in: " + time);
+		//log("imports loaded in: " + time);
 
+	}
+
+
+	private static void log(String text) {
+		LOG.log(System.Logger.Level.INFO, text);
 	}
 
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/Util.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/Util.java
@@ -382,7 +382,6 @@ public final class Util {
 		}
 
 		else { // Malformed link tag
-System.out.println("Unmatched linkContent: " + linkContent);
 			appendTo.append(linkContent);
 		}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/DirLibraryInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/DirLibraryInfo.java
@@ -96,7 +96,7 @@ public class DirLibraryInfo extends LibraryInfo {
 	public ClassFile createClassFileBulk(String entryName) throws IOException {
 		File file = new File(dir, entryName);
 		if (!file.isFile()) {
-			System.err.println("ERROR: Invalid class file: " + file.getAbsolutePath());
+			// TODO: Throw an exception in 4.0.0 release
 			return null;
 		}
 		return new ClassFile(file);

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/JarLibraryInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/JarLibraryInfo.java
@@ -111,7 +111,7 @@ public class JarLibraryInfo extends LibraryInfo {
 			String entryName) throws IOException {
 		JarEntry entry = (JarEntry)jar.getEntry(entryName);
 		if (entry==null) {
-			System.err.println("ERROR: Invalid entry: " + entryName);
+			// TODO: Throw an exception in 4.0.0 release
 			return null;
 		}
 		DataInputStream in = new DataInputStream(

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/Jdk9LibraryInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/Jdk9LibraryInfo.java
@@ -113,7 +113,7 @@ public class Jdk9LibraryInfo extends LibraryInfo {
 				}
 			}
 		}
-		System.err.println("ERROR: Invalid entry: " + entryName);
+		// TODO: Throw an exception in 4.0.0 release
 		return null;
 	}
 
@@ -126,7 +126,7 @@ public class Jdk9LibraryInfo extends LibraryInfo {
 				return c;
 			}
 		}
-		System.err.println("ERROR: Invalid entry: " + entryName);
+		// TODO: Throw an exception in 4.0.0 release
 		return null;
 	}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/LibraryInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/buildpath/LibraryInfo.java
@@ -12,6 +12,7 @@ package org.fife.rsta.ac.java.buildpath;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.System.Logger;
 
 import org.fife.rsta.ac.java.JarManager;
 import org.fife.rsta.ac.java.PackageMapNode;
@@ -37,6 +38,9 @@ import org.fife.rsta.ac.java.classreader.ClassFile;
  */
 public abstract class LibraryInfo implements Comparable<LibraryInfo>,
 		Cloneable {
+
+	private static final Logger LOG = System.
+		getLogger(LibraryInfo.class.getName());
 
 	/**
 	 * The location of the source files corresponding to this library.  This
@@ -219,7 +223,7 @@ public abstract class LibraryInfo implements Comparable<LibraryInfo>,
 			}
 		}
 		else {
-			System.err.println("[ERROR]: Cannot locate JRE jar in " +
+			LOG.log(System.Logger.Level.ERROR, "Cannot locate JRE jar in " +
 								jreHome.getAbsolutePath());
 			mainJar = null;
 		}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/ClassFile.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/ClassFile.java
@@ -11,6 +11,7 @@
 package org.fife.rsta.ac.java.classreader;
 
 import java.io.*;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,10 @@ import org.fife.rsta.ac.java.classreader.constantpool.*;
  */
 public class ClassFile implements AccessFlags {
 
-	private static final boolean DEBUG = false;
+	private static final Logger LOG =
+		System.getLogger(ClassFile.class.getName());
+
+		private static final boolean DEBUG = false;
 
 	/**
 	 * The class file's minor version number.
@@ -136,7 +140,7 @@ public class ClassFile implements AccessFlags {
 
 	private void debugPrint(String text) {
 		if (DEBUG) {
-			System.out.println(text);
+			LOG.log(System.Logger.Level.INFO, text);
 		}
 	}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/Frame.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/Frame.java
@@ -10,6 +10,7 @@
  */
 package org.fife.rsta.ac.java.classreader;
 
+import java.lang.System.Logger;
 import java.util.*;
 
 import org.fife.rsta.ac.java.classreader.attributes.Code;
@@ -23,6 +24,8 @@ import org.fife.rsta.ac.java.classreader.attributes.Code;
  * @version 1.0
  */
 public class Frame {
+
+	private static final Logger LOG = System.getLogger(Frame.class.getName());
 
 	private Stack<String> operandStack;
 	private LocalVarInfo[] localVars;
@@ -64,7 +67,8 @@ public class Frame {
 
 		// NOTE: Other local vars will still be "null" here!  We need to
 		// infer their types from their usage during disassembly/decompilation.
-		System.out.println("NOTE: " + (localVars.length-i) + " unknown localVars slots");
+		LOG.log(System.Logger.Level.DEBUG,
+			"NOTE: " + (localVars.length-i) + " unknown localVars slots");
 
 	}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/MethodInfo.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/MethodInfo.java
@@ -702,7 +702,8 @@ public class MethodInfo extends MemberInfo implements AccessFlags {
 		else {
 			ai = super.readAttribute(in, attrName, attributeLength);
 			//if (ai!=null) { // "Deprecated" attribute returns null
-			//	System.out.println("-------------- " + ai.getName());
+			//	LOG.log(System.Logger.Level.WARNING,
+			//    "-------------- " + ai.getName());
 			//}
 		}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/attributes/Code.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/attributes/Code.java
@@ -11,6 +11,7 @@
 package org.fife.rsta.ac.java.classreader.attributes;
 
 import java.io.*;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +33,8 @@ import org.fife.rsta.ac.java.classreader.*;
  * @version 1.0
  */
 public class Code extends AttributeInfo {
+
+	private static final Logger LOG = System.getLogger(Code.class.getName());
 
 	/**
 	 * The parent method.
@@ -292,7 +295,8 @@ public class Code extends AttributeInfo {
 		}
 
 		else {
-			System.out.println("Unsupported Code attribute: " +  attrName);
+			LOG.log(System.Logger.Level.INFO, "Unsupported Code attribute: " +
+				attrName);
 			ai = AttributeInfo.readUnsupportedAttribute(cf, in, attrName,
 														attributeLength);
 		}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/attributes/Signature.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/classreader/attributes/Signature.java
@@ -10,6 +10,7 @@
  */
 package org.fife.rsta.ac.java.classreader.attributes;
 
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -29,6 +30,9 @@ import org.fife.rsta.ac.java.classreader.MethodInfo;
  * @version 1.0
  */
 public class Signature extends AttributeInfo {
+
+	private static final Logger LOG =
+		System.getLogger(Signature.class.getName());
 
 	private String signature;
 
@@ -76,12 +80,14 @@ public class Signature extends AttributeInfo {
 						colon = temp.indexOf(':', offs);
 					}
 					else {
-						System.err.println("WARN: Can't parse signature (1): " + signature);
+						LOG.log(System.Logger.Level.WARNING,
+							"Can't parse signature (1): " + signature);
 						break;
 					}
 				}
 				else {
-					System.err.println("WARN: Can't parse signature (2): " + signature);
+					LOG.log(System.Logger.Level.WARNING,
+						"Can't parse signature (2): " + signature);
 					break;
 				}
 			}
@@ -161,8 +167,9 @@ public class Signature extends AttributeInfo {
 			}
 
 			else {
-				System.out.println("TODO: Unhandled method signature for " +
-						mi.getName() + ": " + signature);
+				LOG.log(System.Logger.Level.INFO,
+					"TODO: Unhandled method signature for " + mi.getName() +
+					": " + signature);
 			}
 
 		}
@@ -208,8 +215,9 @@ public class Signature extends AttributeInfo {
 			}
 
 			else {
-				System.out.println("TODO: Unhandled method signature for " +
-						mi.getName() + ": " + signature);
+				LOG.log(System.Logger.Level.INFO,
+					"TODO: Unhandled method signature for " + mi.getName() +
+					": " + signature);
 			}
 
 		}
@@ -334,8 +342,8 @@ public class Signature extends AttributeInfo {
 					int offs = skipLtGt(str, lt+1);
 					// There should be a ';' after type parameters
 					if (offs==str.length() || str.charAt(offs)!=';') {
-						System.out.println("TODO: " + errorDesc +
-								mi.getName() + ": " + signature);
+						LOG.log(System.Logger.Level.INFO, "TODO: " + errorDesc +
+							mi.getName() + ": " + signature);
 						type = "ERROR_PARSING_METHOD_SIG";
 					}
 					else {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/lexer/Scanner.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/lexer/Scanner.java
@@ -13,6 +13,7 @@ package org.fife.rsta.ac.java.rjc.lexer;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.Reader;
+import java.lang.System.Logger;
 import java.util.List;
 import java.util.Stack;
 import javax.swing.text.BadLocationException;
@@ -28,6 +29,9 @@ import javax.swing.text.Position;
  * @version 1.0
  */
 public class Scanner {
+
+	private static final Logger LOG =
+		System.getLogger(Scanner.class.getName());
 
 	private static final boolean DEBUG = false;
 
@@ -157,10 +161,10 @@ private void pushOntoStack(Token t) {
 	private void debugPrintToken(Token t) {
 		if (DEBUG) {
 			if (t==null) {
-				System.out.println("... null");
+				LOG.log(System.Logger.Level.INFO, "... null");
 			}
 			else {
-				System.out.println("... " + t);
+				LOG.log(System.Logger.Level.INFO, "... " + t);
 			}
 		}
 	}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/parser/ASTFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/parser/ASTFactory.java
@@ -12,6 +12,7 @@ package org.fife.rsta.ac.java.rjc.parser;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,9 @@ import org.fife.rsta.ac.java.rjc.notices.ParserNotice;
  * @version 1.0
  */
 public class ASTFactory implements TokenTypes {
+
+	private static final Logger LOG =
+		System.getLogger(ASTFactory.class.getName());
 
 	private static final boolean DEBUG = false;
 
@@ -1533,7 +1537,7 @@ OUTER:
 
 	private static void log(String msg) {
 		if (DEBUG) {
-			System.out.println(msg);
+			LOG.log(System.Logger.Level.INFO, msg);
 		}
 	}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/parser/Main.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/rjc/parser/Main.java
@@ -11,6 +11,7 @@
 package org.fife.rsta.ac.java.rjc.parser;
 
 import java.io.*;
+import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -26,6 +27,8 @@ import org.fife.rsta.ac.java.rjc.lexer.Scanner;
  * @version 1.0
  */
 public final class Main {
+
+	private static final Logger LOGGER = System.getLogger(Main.class.getName());
 
 	/**
 	 * If this system property is set to "<code>true</code>",
@@ -47,7 +50,7 @@ public final class Main {
 
 	private static void log(Object text) {
 		if (LOG) {
-			System.out.println(text);
+			LOGGER.log(System.Logger.Level.INFO, text);
 		}
 	}
 
@@ -124,7 +127,7 @@ public final class Main {
 				//log(cu);
 				log(file.getAbsolutePath() + " (" + file.length() + "): " + time + " ms");
 			} catch (InternalError ie) {
-				System.err.println(file.getAbsolutePath());
+				log(file.getAbsolutePath());
 				ie.printStackTrace();
 				System.exit(1);
 			}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/tree/TypeDeclarationTreeNode.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/java/tree/TypeDeclarationTreeNode.java
@@ -92,10 +92,7 @@ class TypeDeclarationTreeNode extends JavaTreeNode {
 		IconFactory fact = IconFactory.get();
 		Icon mainIcon = fact.getIcon(iconName);
 
-		if (mainIcon==null) { // Unknown type ???
-			System.out.println("*** " + typeDec);
-		}
-		else {
+		if (mainIcon!=null) { // TODO: Better handling for unknown types
 			DecoratableIcon di = new DecoratableIcon(mainIcon);
 			di.setDeprecated(typeDec.isDeprecated());
 			Modifiers mods = typeDec.getModifiers();

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/jsp/TldFile.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/jsp/TldFile.java
@@ -110,11 +110,6 @@ public class TldFile {
 				//System.out.println(entry.getName());
 				InputStream in = jar.getInputStream(entry);
 				elems = parseTld(in);
-				/*
-				for (int i=0; i<elems.size(); i++) {
-					System.out.println(elems.get(i));
-				}
-				*/
 				in.close();
 			}
 		}
@@ -130,13 +125,6 @@ public class TldFile {
 		List<TldElement> tldElems = new ArrayList<>();
 
 		BufferedInputStream bin = new BufferedInputStream(in);
-		//BufferedReader r = new BufferedReader(new InputStreamReader(bin));
-		//String line = null;
-		//while ((line=r.readLine())!=null) {
-		//	System.out.println(line);
-		//}
-		//r.close();
-		//System.exit(0);
 
 		Document doc;
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/perl/PerlCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/perl/PerlCompletionProvider.java
@@ -164,7 +164,6 @@ public class PerlCompletionProvider extends CCompletionProvider {
 		String text = p.getAlreadyEnteredText(comp);
 		char firstChar = text.length()==0 ? 0 : text.charAt(0);
 		if (firstChar!='$' && firstChar!='@' && firstChar!='%') {
-			System.out.println("DEBUG: No use matching variables, exiting");
 			return null;
 		}
 

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/php/PhpCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/php/PhpCompletionProvider.java
@@ -91,8 +91,6 @@ public class PhpCompletionProvider extends HtmlCompletionProvider {
 	 */
 	public void loadPhpCompletionsFromXML(InputStream in) throws IOException {
 
-		long start = System.currentTimeMillis();
-
 		SAXParserFactory factory = SAXParserFactory.newInstance();
 		CompletionXMLParser handler = new CompletionXMLParser(this);
         try (BufferedInputStream bin = new BufferedInputStream(in)) {
@@ -109,9 +107,6 @@ public class PhpCompletionProvider extends HtmlCompletionProvider {
             }
         } catch (SAXException | ParserConfigurationException e) {
             throw new IOException(e.toString());
-        } finally {
-            long time = System.currentTimeMillis() - start;
-            System.out.println("XML loaded in: " + time + "ms");
         }
 
 	}

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/sh/ShellFunctionCompletion.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/sh/ShellFunctionCompletion.java
@@ -107,21 +107,18 @@ public class ShellFunctionCompletion extends FunctionCompletion {
 		Matcher m = p.matcher(text);
 		StringBuffer sb = new StringBuffer("<html><pre>");
 		while ((m.find())) {
-			System.out.println("... found '" + m.group() + "'");
 			String group = m.group();
 			if (group.startsWith("_")) {
 				sb.append("<u>");
 				String replacement = group.replaceAll("_\\010", "");
 				replacement = quoteReplacement(replacement);
 				m.appendReplacement(sb, replacement);
-				System.out.println("--- '" + replacement);
 				sb.append("</u>");
 			}
 			else {
 				String replacement = group.replaceAll(".\\010.", "");
 				replacement = quoteReplacement(replacement);
 				m.appendReplacement(sb, replacement);
-				System.out.println("--- '" + replacement);
 			}
 		}
 		m.appendTail(sb);

--- a/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/AboutDialog.java
+++ b/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/AboutDialog.java
@@ -198,13 +198,12 @@ public class AboutDialog extends JDialog {
 		SpringLayout layout;
 		try {
 			layout = (SpringLayout)parent.getLayout();
-		} catch (ClassCastException cce) {
-			System.err.println("The first argument to makeCompactGrid " +
-							"must use SpringLayout.");
+		} catch (ClassCastException cce) { // Never happens
+			cce.printStackTrace();
 			return;
 		}
 
-		//Align all cells in each column and make them the same width.
+		// Align all cells in each column and make them the same width.
 		Spring x = Spring.constant(initialX);
 		for (int c = 0; c < cols; c++) {
 			Spring width = Spring.constant(0);

--- a/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/DemoRootPane.java
+++ b/RSTALanguageSupportDemo/src/main/java/org/fife/rsta/ac/demo/DemoRootPane.java
@@ -211,7 +211,6 @@ setContentPane(cp);
 	 */
 	@Override
 	public void hyperlinkUpdate(HyperlinkEvent e) {
-	    System.out.println("Hyperlink event: " + e.getEventType());
 		if (e.getEventType()==HyperlinkEvent.EventType.ACTIVATED) {
 			URL url = e.getURL();
 			if (url==null) {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -83,14 +83,12 @@
 		<property name="maximum" value="0"/>
 		<property name="message" value="Line has trailing spaces."/>
 	</module>
-<!--
 	<module name="RegexpSingleline">
 		<property name="format" value="(?&lt;!//)\s*System\.(?:out|err)\.println\("/>
 		<property name="minimum" value="0"/>
 		<property name="maximum" value="0"/>
 		<property name="message" value="Do not use System.out.println or System.err.println"/>
 	</module>
--->
 
 	<!-- Checks for Headers                                               -->
 	<!-- See https://checkstyle.sourceforge.io/checks/header/index.html   -->

--- a/config/checkstyle/lsSuppressions.xml
+++ b/config/checkstyle/lsSuppressions.xml
@@ -20,4 +20,7 @@
 
     <!-- Types that are capitalized as defined in the JVM specification. -->
     <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]java[\\/]classreader[\\/]constantpool[\\/]ConstantTypes.*" checks="ConstantName"/>
+
+    <!-- Files that have legitimate reasons to include the text "System.(out|error).println" -->
+    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]java[\\/]JavaShorthandCompletionCache.*" checks="RegexpSingleline"/>
 </suppressions>


### PR DESCRIPTION
Like it says on the tin. Remove all calls to `System.out.println()` and `System.err.println()`, preferring `System.Logger` now that this library's baseline is Java 11.