### PR TITLE
Enable RequireEmptyLineBeforeBlockTagGroup checkstyle rule for JS support

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptCompletionProvider.java
@@ -97,7 +97,8 @@ public class JavaScriptCompletionProvider extends
 	}
 
 	/**
-	 * load the comment completions from the shorthand cache
+	 * load the comment completions from the shorthand cache.
+	 *
 	 * @param shorthandCache
 	 */
 	private void setCommentCompletions(ShorthandCompletionCache shorthandCache){

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
@@ -119,6 +119,7 @@ public final class JavaScriptHelper {
 
 	/**
 	 * @param node AstNode to look for function
+	 * @param provider The provider to look it up in.
 	 * @return function lookup name from it's AstNode. i.e. concat function name
 	 *         and parameters. If no function is found, then return null
 	 */
@@ -233,6 +234,7 @@ case Token.EXPR_RESULT:
 	 * e.g
 	 * var a = [1, 2, 3];
 	 * var b = a[1]; //b resolves to Number
+	 *
 	 * @param node
 	 * @param provider
 	 * @return
@@ -255,6 +257,7 @@ case Token.EXPR_RESULT:
 
 	/**
 	 * Create array type from AstNode and try to determine the array type
+	 *
 	 * @param typeNode
 	 * @param provider
 	 * @return
@@ -276,6 +279,7 @@ case Token.EXPR_RESULT:
 
 	/**
 	 * Find the array type from ArrayLiteral. Iterates through elements and checks all the types are the same
+	 *
 	 * @param arrayLit
 	 * @param provider
 	 * @return TypeDeclaration if all elements are of the same type else TypeDeclarationFactory.getDefaultTypeDeclaration();
@@ -495,8 +499,9 @@ case Token.EXPR_RESULT:
 	 * Convenience method to lookup TypeDeclaration through the
 	 * TypeDeclarationFactory.
 	 *
-	 * @param name
-	 * @return
+	 * @param name The type declaration to look up.
+	 * @param provider The provider to look it up in.
+	 * @return The type declaration.
 	 */
 	public static TypeDeclaration getTypeDeclaration(String name, SourceCompletionProvider provider) {
 		return provider.getTypesFactory().getTypeDeclaration(name);
@@ -538,8 +543,8 @@ case Token.EXPR_RESULT:
 	 *
 	 * String should be trimmed at the 1, not the 2,
 	 *
-	 * @param text
-	 * @return
+	 * @param text The text to trim.
+	 * @return The trimmed text.
 	 */
 	public static String trimFromLastParam(String text) {
 		int trim = 0;

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptParser.java
@@ -105,6 +105,7 @@ public class JavaScriptParser extends AbstractParser {
 	 * Creates options for Rhino based off of the user's preferences.
 	 *
 	 * @param errorHandler The container for errors found while parsing.
+	 * @param langSupport The language support to configure, which may be {@code null}.
 	 * @return The properties for the JS compiler to use.
 	 */
 	public static CompilerEnvirons createCompilerEnvironment(ErrorReporter

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
@@ -312,7 +312,8 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 	}
 
 	/**
-	 * Load ECMA JavaScript class completions
+	 * Load ECMA JavaScript class completions.
+	 *
 	 * @param set completion set
 	 * @param text
 	 */
@@ -337,7 +338,8 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 
 	/**
 	 * returns the Base class for the source completion provider. This is represented by a class name or ECMA lookup name
-	 * e.g. set to 'Global' for server side or 'Window' for client JavaScript support
+	 * e.g. set to 'Global' for server side or 'Window' for client JavaScript support.
+	 *
      * @return base class for the completion provider
      */
 	public String getSelf() {
@@ -436,7 +438,8 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 
 	/**
 	 * Convenience method to call variable resolver for non-local variables
-	 * i.e. does NOT try to resolve name to any local variables (just pre-processed or system)
+	 * i.e. does NOT try to resolve name to any local variables (just pre-processed or system).
+	 *
 	 * @param name
 	 * @return JavaScript variable declaration
 	 */
@@ -607,7 +610,8 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 	}
 
 	/**
-	 * Set type declaration options for parser
+	 * Set type declaration options for parser.
+	 *
 	 * @param typeDeclarationOptions
 	 */
 	public void setTypeDeclationOptions(TypeDeclarationOptions typeDeclarationOptions) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/CodeBlock.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/CodeBlock.java
@@ -181,6 +181,7 @@ public class CodeBlock {
 
 	/**
 	 * Sets the start offset of this code block.
+	 *
 	 * @param start the start offset
 	 * @see #getStartOffset()
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/JavaScriptDeclaration.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/JavaScriptDeclaration.java
@@ -55,6 +55,7 @@ public abstract class JavaScriptDeclaration {
 
 	/**
 	 * Sets the start offset of this declaration.
+	 *
 	 * @param start the start offset
 	 * @see #getStartOffSet()
 	 */
@@ -82,6 +83,7 @@ public abstract class JavaScriptDeclaration {
 	/**
 	 * Set the JavaScript options associated with this declaration.
 	 * These are used to defined whether options are available to
+	 *
 	 * @param options
 	 */
 	public void setTypeDeclarationOptions(TypeDeclarationOptions options) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/JavaScriptVariableDeclaration.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/JavaScriptVariableDeclaration.java
@@ -32,6 +32,7 @@ public class JavaScriptVariableDeclaration extends JavaScriptDeclaration {
 	 * @param name of the variable
 	 * @param offset position within script
 	 * @param provider JavaScript source provider
+	 * @param block The code block.
 	 */
 	public JavaScriptVariableDeclaration(String name, int offset,
 			SourceCompletionProvider provider, CodeBlock block) {
@@ -51,7 +52,8 @@ public class JavaScriptVariableDeclaration extends JavaScriptDeclaration {
 	}
 
 	/**
-	 * Set the TypeDeclaration for the AstNode. Stores the original value so it can be reset
+	 * Set the TypeDeclaration for the AstNode. Stores the original value so it can be reset.
+	 *
 	 * @param typeNode
 	 * @param overrideOriginal
 	 * @see #resetVariableToOriginalType()

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/TypeDeclarationOptions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/TypeDeclarationOptions.java
@@ -28,6 +28,8 @@ public class TypeDeclarationOptions {
 
 	/**
 	 * set the owner script name.
+	 *
+	 * @param ownerScriptName The name of the script that owns this type declaration.
 	 */
 	public void setOwnerScriptName(String ownerScriptName) {
 		this.ownerScriptName = ownerScriptName;
@@ -42,6 +44,8 @@ public class TypeDeclarationOptions {
 
 	/**
 	 * set whether the type declaration supports hyperlinks.
+	 *
+	 * @param supportsLinks Whether the type declaration supports hyperlinks.
 	 */
 	public void setSupportsLinks(boolean supportsLinks) {
 		this.supportsLinks = supportsLinks;
@@ -55,7 +59,9 @@ public class TypeDeclarationOptions {
 	}
 
 	/**
-	 * set whether the type declaration has been created from a pre-processed script.
+	 * Set whether the type declaration has been created from a pre-processed script.
+	 *
+	 * @param preProcessing Whether the script was pre-processed.
 	 */
 	public void setPreProcessing(boolean preProcessing) {
 		this.preProcessing = preProcessing;

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptFunctionType.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptFunctionType.java
@@ -96,6 +96,7 @@ public final class JavaScriptFunctionType {
 	/**
 	 * Compare this JavaScriptFunctionType with another and return a weight integer based on the parameters matching or
 	 * whether the parameters are compatible.
+	 *
 	 * @param compareType method to compare with this
 	 * @param provider SourceCompletionProvider
 	 * @param isJavaScriptType TODO
@@ -135,6 +136,7 @@ public final class JavaScriptFunctionType {
 
 	/**
 	 * Convert parameter into TypeDeclaration.
+	 *
 	 * @param type
 	 * @param provider
 	 * @return
@@ -154,6 +156,7 @@ public final class JavaScriptFunctionType {
 	/**
 	 * Converts TypeDeclaration into Java Class and  compares whether another parameter is compatible based
 	 * on JSR-223.
+	 *
 	 * @param param parameter to compare
 	 * @param compareParam compare parameter
 	 * @param provider SourceCompletionProvider
@@ -310,6 +313,7 @@ public final class JavaScriptFunctionType {
 
 	/**
 	 * Converts TypeDeclaration qualified name to Java Class.
+	 *
 	 * @param name
 	 * @return
 	 * @throws ClassNotFoundException
@@ -377,6 +381,7 @@ public final class JavaScriptFunctionType {
 
 	/**
 	 * Convenience method to parse function string and converts to JavaScriptFunctionType
+	 *
 	 * @param function String to parse e.g. convertValue(java.util.String val);
 	 * @param provider used for type conversions
 	 * @return The function type.
@@ -417,6 +422,7 @@ public final class JavaScriptFunctionType {
 
 	/**
 	 * Converts JavaScript class name to integer code.
+	 *
 	 * @param clsName
 	 * @return
 	 * @throws ClassNotFoundException

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptType.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptType.java
@@ -101,6 +101,7 @@ public class JavaScriptType {
 
 	/**
 	 * Set the class type completion e.g. String, Number
+	 *
 	 * @param classType Completion to format the class
 	 */
 	public void setClassTypeCompletion(JSCompletion classType) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptTypesFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptTypesFactory.java
@@ -254,6 +254,7 @@ public abstract class JavaScriptTypesFactory {
 	 * 			<LI>!staticsOnly && public return true; //All public methods and fields</LI>
 	 * 			<LI>Built in JavaScript type and public or protected return true; //All public/protected built in JSType (org.fife.rsta.ac.js.ecma.api.ecma3 package) methods and fields</LI>
 	 * 		</OL>
+	 *
 	 * @param access - access flag to test
 	 * @param staticsOnly - whether loading static methods and fields only
 	 * @param isJSType - is a built in JavasScript type

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/RhinoJavaScriptTypesFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/RhinoJavaScriptTypesFactory.java
@@ -79,6 +79,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 
 	/**
 	 * Validate whether the newImports and old imports contain the same values
+	 *
 	 * @param newImports
 	 * @param oldImports
 	 * @return
@@ -117,6 +118,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 
 	/**
 	 * Remove all TypeDeclarations from the TypeDeclarationFactory from the JavaScriptType and all it's extended classes
+	 *
 	 * @param type
 	 */
 	private void removeAllTypes(JavaScriptType type) {
@@ -157,6 +159,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 
 	/**
 	 * Look for class file using imported classes
+	 *
 	 * @param manager
 	 * @param name
 	 * @return
@@ -174,7 +177,8 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 	}
 
 	/**
-	 * Look for class file using imported packages
+	 * Look for class file using imported packages.
+	 *
 	 * @param manager
 	 * @param name
 	 * @return

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/JavaScriptParser.java
@@ -42,6 +42,7 @@ public abstract class JavaScriptParser {
 
 	/**
 	 * If options are null, then it is assumed that the main editor text is being parsed.
+	 *
 	 * @return whether options is not null and is in pre-processing mode.
 	 *
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/RhinoJavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/RhinoJavaScriptAstParser.java
@@ -33,6 +33,7 @@ public class RhinoJavaScriptAstParser extends JavaScriptAstParser {
 
 	/**
 	 * Clear the importPackage and importClass cache
+	 *
 	 * @param provider SourceCompletionProvider
 	 */
 	public void clearImportCache(SourceCompletionProvider provider) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/TypeDeclarationFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/TypeDeclarationFactory.java
@@ -90,6 +90,7 @@ public class TypeDeclarationFactory {
 
 	/**
 	 * Returns whether the qualified name is a built-in JavaScript type
+	 *
 	 * @param td The type declaration to check.
 	 * @return Whether it is a built-in JS type.
 	 */
@@ -100,6 +101,7 @@ public class TypeDeclarationFactory {
 
 	/**
 	 * Returns the type declaration.
+	 *
 	 * @param name
 	 * @return Lookup type declaration from name. If the
 	 *         <code>TypeDeclaration</code> cannot be found, then lookup using
@@ -123,9 +125,12 @@ public class TypeDeclarationFactory {
 
 	/**
 	 * The API may have its own types, so these need converting back to
-	 * JavaScript types e.g. JSString == String, JSNumber == Number
+	 * JavaScript types e.g. JSString == String, JSNumber == Number.
+	 *
+	 * @param lookupName The name to look up.
+	 * @param qualified Whether it is fully qualified.
+	 * @return The type.
 	 */
-
 	public String convertJavaScriptType(String lookupName, boolean qualified) {
 		if (lookupName != null) {
 			if (TypeDeclarations.NULL_TYPE.equals(lookupName)) { // void has no type
@@ -183,8 +188,9 @@ public class TypeDeclarationFactory {
 
 	/**
 	 * Answers the question whether an object can be instantiated (i.e. has a constructor)
-	 * @param name name of class to test
 	 *
+	 * @param name name of class to test
+	 * @return Whether the object can be instantiated.
 	 */
 	public boolean canJavaScriptBeInstantiated(String name) {
 		return ecma.canECMAObjectBeInstantiated(name);

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/ecma/TypeDeclarations.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/ecma/TypeDeclarations.java
@@ -183,8 +183,8 @@ public abstract class TypeDeclarations {
 	/**
 	 * Returns whether the qualified name is a built-in JavaScript type
 	 *
-	 * @param td
-	 * @return
+	 * @param td The type declaration, which may be {@code null}.
+	 * @return Whether it is a built-in JS type.
 	 */
 	public boolean isJavaScriptType(TypeDeclaration td) {
 		return td != null && td.getPackageName() != null
@@ -255,8 +255,9 @@ public abstract class TypeDeclarations {
 	/**
 	 * Answers the question whether an object can be instantiated (i.e. has a constructor)
 	 * Note, only tests ECMA objects
-	 * @param name name of class to test
 	 *
+	 * @param name name of class to test
+	 * @return Whether the object can be instantiated.
 	 */
 	public boolean canECMAObjectBeInstantiated(String name) {
 		String tempName = javascriptReverseLookup.get(name);

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/History.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/History.java
@@ -9,7 +9,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.JSNumber;
 public abstract class History implements HistoryFunctions {
 
 	/**
-	  * Object History()
+	  * Object History().
+	 *
 	  * @super Object
 	  * @constructor
 	  * @since Common Usage, no standard
@@ -39,7 +40,8 @@ public abstract class History implements HistoryFunctions {
     public History prototype;
 
 	/**
-	 * Property length
+	 * Property length.
+	 *
 	 * @type Number
 	 * @memberOf History
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Location.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Location.java
@@ -8,7 +8,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.JSString;
 public abstract class Location implements LocationFunctions {
 
 	/**
-	  * Object Location()
+	  * Object Location().
+	  *
 	  * @super Object
 	  * @constructor
 	  * @since Common Usage, no standard
@@ -16,7 +17,7 @@ public abstract class Location implements LocationFunctions {
 	public Location(){}
 
     /**
-     * <b>property constructor</b>
+     * <b>property constructor</b>.
      *
      * @type Function
      * @memberOf Object
@@ -27,7 +28,7 @@ public abstract class Location implements LocationFunctions {
     protected JSFunction constructor;
 
     /**
-     * <b>property prototype</b>
+     * <b>property prototype</b>.
      *
      * @type Location
      * @memberOf Location
@@ -36,7 +37,7 @@ public abstract class Location implements LocationFunctions {
     public Location prototype;
 
     /**
-     * <b>property location</b>
+     * <b>property location</b>.
      *
      * @type Location
      * @memberOf Location
@@ -45,42 +46,48 @@ public abstract class Location implements LocationFunctions {
     public Location location;
 
     /**
-	 * Property hash
+	 * Property hash.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString hash;
 
 	/**
-	 * Property host
+	 * Property host.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString host;
 
 	/**
-	 * Property hostname
+	 * Property hostname.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString hostname;
 
 	/**
-	 * Property href
+	 * Property href.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString href;
 
 	/**
-	 * Property pathname
+	 * Property pathname.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString pathname;
 
 	/**
-	 * Property port
+	 * Property port.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
@@ -88,13 +95,15 @@ public abstract class Location implements LocationFunctions {
 
 	/**
 	 * Property protocol
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */
 	public JSString protocol;
 
 	/**
-	 * Property search
+	 * Property search.
+	 *
 	 * @type String
 	 * @memberOf Location
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Navigator.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Navigator.java
@@ -10,7 +10,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.JS5Array;
 public abstract class Navigator implements NavigatorFunctions {
 
 	/**
-	 * Object Navigator()
+	 * Object Navigator().
+	 *
 	 * @super Object
 	 * @constructor
 	 * @since Common Usage, no standard
@@ -38,56 +39,64 @@ public abstract class Navigator implements NavigatorFunctions {
    public Navigator prototype;
 
 	/**
-	 * Property appCodeName
+	 * Property appCodeName.
+	 *
 	 * @type String
 	 * @memberOf Navigator
 	 */
 	public JSString appCodeName;
 
 	/**
-	 * Property appName
+	 * Property appName.
+	 *
 	 * @type String
 	 * @memberOf Navigator
 	 */
 	public JSString appName;
 
 	/**
-	 * Property appVersion
+	 * Property appVersion.
+	 *
 	 * @type String
 	 * @memberOf Navigator
 	 */
 	public JSString appVersion;
 
 	/**
-	 * Property cookieEnabled
+	 * Property cookieEnabled.
+	 *
 	 * @type Boolean
 	 * @memberOf Navigator
 	 */
 	public JSBoolean cookieEnabled;
 
 	/**
-	 * Property mimeTypes
+	 * Property mimeTypes.
+	 *
 	 * @type Array
 	 * @memberOf Navigator
 	 */
 	public JS5Array mimeTypes;
 
 	/**
-	 * Property platform
+	 * Property platform.
+	 *
 	 * @type String
 	 * @memberOf Navigator
 	 */
 	public JSString platform;
 
 	/**
-	 * Property plugins
+	 * Property plugins.
+	 *
 	 * @type Array
 	 * @memberOf Navigator
 	 */
 	public JS5Array plugins;
 
 	/**
-	 * Property userAgent
+	 * Property userAgent.
+	 *
 	 * @type String
 	 * @memberOf Navigator
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Window.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/Window.java
@@ -13,7 +13,7 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.JSString;
 public abstract class Window extends JSGlobal implements WindowFunctions {
 
 	/**
-     * Object Window()
+     * Object Window().
      *
      * @constructor
      * @extends Global
@@ -21,7 +21,7 @@ public abstract class Window extends JSGlobal implements WindowFunctions {
 	public Window(){}
 
 	/**
-     * <b>property constructor</b>
+     * <b>property constructor</b>.
      *
      * @type Function
      * @memberOf Object
@@ -32,7 +32,7 @@ public abstract class Window extends JSGlobal implements WindowFunctions {
     protected JSFunction constructor;
 
     /**
-     * <b>property prototype</b>
+     * <b>property prototype</b>.
      *
      * @type Window
      * @memberOf Window
@@ -43,63 +43,72 @@ public abstract class Window extends JSGlobal implements WindowFunctions {
     public Window prototype;
 
 	/**
-	 * Property closed
+	 * Property closed.
+	 *
 	 * @type Boolean
 	 * @memberOf Window
 	 */
 	public JSBoolean closed;
 
 	/**
-	 * Property window
+	 * Property window.
+	 *
 	 * @type Window
 	 * @memberOf Window
 	 */
 	public Window window;
 
 	/**
-	 * Property frames
+	 * Property frames.
+	 *
 	 * @type Array
 	 * @memberOf Window
 	 */
 	public JSArray frames;
 
 	/**
-	 * Property defaultStatus
+	 * Property defaultStatus.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */
 	public JSString defaultStatus;
 
 	/**
-	 * Property document
+	 * Property document.
+	 *
 	 * @type Document
 	 * @memberOf Window
 	 */
 	public JSHTMLDocument document;
 
 	/**
-	 * Property history
+	 * Property history.
+	 *
 	 * @type History
 	 * @memberOf Window
 	 */
 	public History history;
 
 	/**
-	 * Property location
+	 * Property location.
+	 *
 	 * @type Location
 	 * @memberOf Window
 	 */
 	public Location location;
 
 	/**
-	 * Property name
+	 * Property name.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */
 	public JSString name;
 
 	/**
-	 * Property navigator
+	 * Property navigator.
+	 *
 	 * @type Navigator
 	 * @memberOf Window
 	 */
@@ -107,217 +116,248 @@ public abstract class Window extends JSGlobal implements WindowFunctions {
 
 
 	/**
-	 * Property opener
+	 * Property opener.
+	 *
 	 * @type Window
 	 * @memberOf Window
 	 */
 	public Window opener;
 
 	/**
-	 * Property outerWidth
+	 * Property outerWidth.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber outerWidth;
 
 	/**
-	 * Property outerHeight
+	 * Property outerHeight.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber outerHeight;
 
 	/**
-	 * Property pageXOffset
+	 * Property pageXOffset.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber pageXOffset;
 
 	/**
-	 * Property pageYOffset
+	 * Property pageYOffset.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber pageYOffset;
 
 	/**
-	 * Property parent
+	 * Property parent.
+	 *
 	 * @type Window
 	 * @memberOf Window
 	 */
 	public Window parent;
 
 	/**
-	 * Property screen
+	 * Property screen.
+	 *
 	 * @type Screen
 	 * @memberOf Window
 	 */
 	public Screen screen;
 
 	/**
-	 * Property status
+	 * Property status.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */
 	public JSString status;
 
 	/**
-	 * Property top
+	 * Property top.
+	 *
 	 * @type Window
 	 * @memberOf Window
 	 */
 	public Window top;
 
 	 /**
-	 * Property innerWidth
+	 * Property innerWidth.
+	  *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber innerWidth;
 
 	/**
-	 * Property innerHeight
+	 * Property innerHeight.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber innerHeight;
 
 	/**
-	 * Property screenX
+	 * Property screenX.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber screenX;
 
 	/**
-	 * Property screenY
+	 * Property screenY.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber screenY;
 
 	/**
-	 * Property screenLeft
+	 * Property screenLeft.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber screenLeft;
 
 	/**
-	 * Property screenTop
+	 * Property screenTop.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber screenTop;
 
 	/**
-	 * Property length
+	 * Property length.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber length;
 
 	/**
-	 * Property scrollbars
+	 * Property scrollbars.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp scrollbars;
 
 	/**
-	 * Property scrollX
+	 * Property scrollX.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber scrollX;
 
 	/**
-	 * Property scrollY
+	 * Property scrollY.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber scrollY;
 
 	/**
-	 * Property content
+	 * Property content.
+	 *
 	 * @type Window
 	 * @memberOf Window
 	 */
 	public Window content;
 
 	/**
-	 * Property menubar
+	 * Property menubar.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp menubar;
 
 	/**
-	 * Property toolbar
+	 * Property toolbar.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp toolbar;
 
 	/**
-	 * Property locationbar
+	 * Property locationbar.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp locationbar;
 
 	/**
-	 * Property personalbar
+	 * Property personalbar.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp personalbar;
 
 	/**
-	 * Property statusbar
+	 * Property statusbar.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp statusbar;
 
 	/**
-	 * Property directories
+	 * Property directories.
+	 *
 	 * @type BarProp
 	 * @memberOf Window
 	 */
 	public BarProp directories;
 
 	/**
-	 * Property scrollMaxX
+	 * Property scrollMaxX.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber scrollMaxX;
 
 	/**
-	 * Property scrollMaxY
+	 * Property scrollMaxY.
+	 *
 	 * @type Number
 	 * @memberOf Window
 	 */
 	public JSNumber scrollMaxY;
 
 	/**
-	 * Property fullScreen
+	 * Property fullScreen.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */
 	public JSString fullScreen;
 
 	/**
-	 * Property frameElement
+	 * Property frameElement.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */
 	public JSString frameElement;
 
 	/**
-	 * Property sessionStorage
+	 * Property sessionStorage.
+	 *
 	 * @type String
 	 * @memberOf Window
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/HistoryFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/HistoryFunctions.java
@@ -9,32 +9,36 @@ public interface HistoryFunctions extends JS5ObjectFunctions {
 
 
 	/**
-	* <b>function back - Loads the previous URL in the history list</b>.
-	* @memberOf History
-	* @see org.fife.rsta.ac.js.ecma.api.client.History History
-	*/
+	 * <b>function back - Loads the previous URL in the history list</b>.
+	 *
+	 * @memberOf History
+	 * @see org.fife.rsta.ac.js.ecma.api.client.History History
+	 */
 	void back();
 
 	/**
-	* <b>function forward - Loads the next URL in the history list</b>.
-	* @memberOf History
-	* @see org.fife.rsta.ac.js.ecma.api.client.History History
-	*/
+	 * <b>function forward - Loads the next URL in the history list</b>.
+	 *
+	 * @memberOf History
+	 * @see org.fife.rsta.ac.js.ecma.api.client.History History
+	 */
 	void forward();
 
 	/**
-	* <b>function go - Loads a specific URL from the history list</b>.
-	* @memberOf History
-	* @param arg goes to the URL within the specific position (-1 goes back one page, 1 goes forward one page)
-	* @see org.fife.rsta.ac.js.ecma.api.client.History History
-	*/
+	 * <b>function go - Loads a specific URL from the history list</b>.
+	 *
+	 * @memberOf History
+	 * @param arg goes to the URL within the specific position (-1 goes back one page, 1 goes forward one page)
+	 * @see org.fife.rsta.ac.js.ecma.api.client.History History
+	 */
 	void go(JSNumber arg);
 
 	/**
-	* <b>function go - Loads a specific URL from the history list</b>.
-	* @memberOf History
-	* @param arg the string must be a partial or full URL, and the function will go to the first URL that matches the string
-	* @see org.fife.rsta.ac.js.ecma.api.client.History History
-	*/
+	 * <b>function go - Loads a specific URL from the history list</b>.
+	 *
+	 * @memberOf History
+	 * @param arg the string must be a partial or full URL, and the function will go to the first URL that matches the string
+	 * @see org.fife.rsta.ac.js.ecma.api.client.History History
+	 */
 	void go(JSString arg);
 }

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/LocationFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/LocationFunctions.java
@@ -8,21 +8,24 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5ObjectFunctions;
 public interface LocationFunctions extends JS5ObjectFunctions {
 
 	/**
-	 * function assign(newURL) method loads a new document
+	 * function assign(newURL) method loads a new document.
+	 *
 	 * @param newURL
 	 * @memberOf Location
 	 */
 	void assign(JSString newURL);
 
 	/**
-	 * function reload(optionalArg) - Reload the current document
+	 * function reload(optionalArg) - Reload the current document.
+	 *
 	 * @param optionalArg - default <i><b>false</b></i> which reloads the page from the cache. Set this paramter to true if you want to force the browser to get the page from the server
 	 * @memberOf Location
 	 */
 	void reload(JSBoolean optionalArg);
 
 	/**
-	 * function replace(newURL) - method replaces the current document with a new one
+	 * function replace(newURL) - method replaces the current document with a new one.
+	 *
 	 * @param newUrl
 	 * @memberOf Location
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/NavigatorFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/NavigatorFunctions.java
@@ -7,7 +7,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5ObjectFunctions;
 public interface NavigatorFunctions extends JS5ObjectFunctions {
 
 	/**
-	 * function javaEnabled() - Specifies whether the browser has Java enabled
+	 * function javaEnabled() - Specifies whether the browser has Java enabled.
+	 *
 	 * @returns true if java is enabled
 	 * @memberOf Navigator
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/WindowFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/client/funtions/WindowFunctions.java
@@ -13,40 +13,46 @@ import org.w3c.dom.Element;
 public interface WindowFunctions extends JS5ObjectFunctions {
 
 	/**
-	 * function alert() Displays an alert box with a message and an OK button
+	 * function alert() Displays an alert box with a message and an OK button.
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 */
 	void alert(JSString arg);
 
 	/**
-	 * function blur() Removes focus from the current window
+	 * function blur() Removes focus from the current window.
+	 *
 	 * @memberOf  Window
 	 */
 	void blur();
 
 	/**
-	 * function clearInterval(arg) Clears a timer set with setInterval()
+	 * function clearInterval(arg) Clears a timer set with setInterval().
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 */
 	void clearInterval(JS5Object arg);
 
 	/**
-	 * function clearTimeout(arg) Clears a timer set with setTimeout()
+	 * function clearTimeout(arg) Clears a timer set with setTimeout().
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 */
 	void clearTimeout(JS5Object arg);
 
 	/**
-	 * function close() Closes the current window
+	 * function close() Closes the current window.
+	 *
 	 * @memberOf  Window
 	 */
 	void close();
 
 	/**
-	 * function confirm() Displays a dialog box with a message and an OK and a Cancel button
+	 * function confirm() Displays a dialog box with a message and an OK and a Cancel button.
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 * @returns Boolean
@@ -54,13 +60,15 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	JSBoolean confirm(JSString arg);
 
 	/**
-	 * function focus() Sets focus to the current window
+	 * function focus() Sets focus to the current window.
+	 *
 	 * @memberOf  Window
 	 */
 	void focus();
 
 	/**
-	 * function getComputedStyle(arg1, arg2)
+	 * function getComputedStyle(arg1, arg2).
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -69,7 +77,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	JS5Object getComputedStyle(Element arg1, JSString arg2);
 
 	/**
-	 * function moveTo(arg1, arg2) Moves a window to the specified position
+	 * function moveTo(arg1, arg2) Moves a window to the specified position.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -77,7 +86,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	void moveTo(JSNumber arg1,JSNumber arg2);
 
 	/**
-	 * function moveBy(arg1, arg2) Moves a window relative to its current position
+	 * function moveBy(arg1, arg2) Moves a window relative to its current position.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -97,20 +107,23 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	Window open(JSString url, JSString name, JSString specs, JSBoolean replace);
 
 	/**
-	 * function print() Prints the content of the current window
+	 * function print() Prints the content of the current window.
+	 *
 	 * @memberOf  Window
 	 */
 	void print();
 
 	/**
-	 * function prompt(arg1, arg2)  Displays a dialog box that prompts the visitor for input
+	 * function prompt(arg1, arg2)  Displays a dialog box that prompts the visitor for input.
+	 *
 	 * @memberOf  Window
 	 * @returns String
 	 */
 	JSString prompt();
 
 	/**
-	 * function resizeTo(arg1, arg2) Resizes the window to the specified width and height
+	 * function resizeTo(arg1, arg2) Resizes the window to the specified width and height.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -118,7 +131,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	void resizeTo(JSNumber arg1, JSNumber arg2);
 
 	/**
-	 * function resizeBy(arg1, arg2) Resizes the window by the specified pixels
+	 * function resizeBy(arg1, arg2) Resizes the window by the specified pixels.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -126,7 +140,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	void resizeBy(JSNumber arg1, JSNumber arg2);
 
 	/**
-	 * function scrollTo(arg1, arg2) Scrolls the content to the specified coordinates
+	 * function scrollTo(arg1, arg2) Scrolls the content to the specified coordinates.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -134,7 +149,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	void scrollTo(JSNumber arg1, JSNumber arg2);
 
 	/**
-	 * function scrollBy(arg1, arg2) Scrolls the content by the specified number of pixels
+	 * function scrollBy(arg1, arg2) Scrolls the content by the specified number of pixels.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -142,7 +158,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	void scrollBy(JSNumber arg1, JSNumber arg2);
 
 	/**
-	 * function setInterval(arg1, arg2) Calls a function or evaluates an expression at specified intervals (in milliseconds)
+	 * function setInterval(arg1, arg2) Calls a function or evaluates an expression at specified intervals (in milliseconds).
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -151,7 +168,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	JSNumber setInterval(JSObject arg1, JSNumber arg2);
 
 	/**
-	 * function setTimeout(arg1, arg2) Calls a function or evaluates an expression after a specified number of milliseconds
+	 * function setTimeout(arg1, arg2) Calls a function or evaluates an expression after a specified number of milliseconds.
+	 *
 	 * @param arg1
 	 * @param arg2
 	 * @memberOf  Window
@@ -161,6 +179,7 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 
 	/**
 	 * function atob(arg) The atob() method of window object decodes a string of data which has been encoded using base-64 encoding. For example, the window.btoa method takes a binary string as a parameter and returns a base-64 encoded string.
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 * @returns String
@@ -169,6 +188,7 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 
 	/**
 	 * function btoa(arg) The btoa() method of window object is used to convert a given string to an encoded data (using base-64 encoding) string.
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 * @returns {String}
@@ -176,7 +196,8 @@ public interface WindowFunctions extends JS5ObjectFunctions {
 	JSString btoa(JSString arg);
 
 	/**
-	 * function setResizable(arg)
+	 * function setResizable(arg).
+	 *
 	 * @param arg
 	 * @memberOf  Window
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/E4XQName.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/E4XQName.java
@@ -35,7 +35,8 @@ public abstract class E4XQName implements JSObjectFunctions {
 	}
 
 	/**
-     * Object QName(namespace, name)
+     * Object QName(namespace, name).
+	 *
      * @constructor
      * @param namespace optional namespace part of QName
      * @param name localname of the QName

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/E4XXML.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/E4XXML.java
@@ -123,6 +123,7 @@ public abstract class E4XXML implements E4XXMLFunctions {
 	 *   return comments;
 	 * }
      * </pre>
+	 *
      * @return an object containing the properties of the XML constructor used for storing XML settings.
      * @memberOf XML
      * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XGlobalFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XGlobalFunctions.java
@@ -9,6 +9,7 @@ public interface E4XGlobalFunctions extends JS5ObjectFunctions {
 
 	/**
 	 * <b>function isXMLName(name)</b> determines whether name is a valid XML name.
+	 *
 	 * @param name The name to be tested.
 	 * @returns examines the given value and determines whether it is a valid XML {@code name} that can be used as an XML element or attribute name. If so, it returns <b>true</b>, otherwise it returns <b>false</b>.
 	 * @memberOf Global

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XXMLFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XXMLFunctions.java
@@ -16,6 +16,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function addNamespace(namespace)</b> adds a namespace declaration to the in scope namespaces for this XML object and returns this XML object.
+	 *
 	 * @param namespace The namespace to be added.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -35,6 +36,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Add a new child element to the end of Jim's employee element
 	 * e.employee.(name == "Jim").appendChild(<hobby>snorkeling</hobby>);}
 	 * </pre>
+	 *
 	 * @param xml to be appended.
 	 * @returns <b>this</b> XML Object
 	 * @memberOf XML
@@ -51,6 +53,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // get the id of the employee named Jim
 	 * e.employee.(name == "Jim").attribute("id");
 	 * </pre>
+	 *
 	 * @param attributeName name of attribute to find.
 	 * @returns an XMLList containing zero or one XML attributes associated with this XML object that have the given <b><i>attributeName</i></b>.
 	 * @memberOf XML
@@ -71,6 +74,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
      *   }
      *  }
 	 * </pre>
+	 *
 	 * @returns an XMLList containing the XML attributes of this object.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -87,6 +91,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * var name = customer.child("name"); // equivalent to: var name = customer.name;
 	 * var secondChild = customer.child(1); // equivalent to: var secondChild = customer.*[1]
 	 * </pre>
+	 *
 	 * @param propertyName name of XML element to find.
 	 * @returns the list of children in this XML object matching the given propertyName. If propertyName is a numeric index, the child method returns a list containing the child at the ordinal position identified by <b><i>propertyName</i></b>.
 	 * @memberOf XML
@@ -103,6 +108,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * var name = customer.child("name"); // equivalent to: var name = customer.name;
 	 * var secondChild = customer.child(1); // equivalent to: var secondChild = customer.*[1]
 	 * </pre>
+	 *
 	 * @param propertyName name of XML element to find.
 	 * @returns the list of children in this XML object matching the given propertyName. If propertyName is a numeric index, the child method returns a list containing the child at the ordinal position identified by <b><i>propertyName</i></b>.
 	 * @memberOf XML
@@ -119,6 +125,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Get the ordinal index of the employee named Joe.
 	 * var joeindex = e.employee.(name == "Joe").childIndex();
 	 * </pre>
+	 *
 	 * @returns a Number representing the ordinal position of this XML object within the context of its parent.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -135,6 +142,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // <name>Jim</name>, <age>25</age> and <hobby>Snorkeling</hobby>
 	 * var employees = e.employee[0].children();
 	 * </pre>
+	 *
 	 * @returns an XMLList containing all the properties of this XML object in order.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -144,6 +152,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function comments()</b> returns list of comments for the XML element.
+	 *
 	 * @returns an XMLList containing the properties of this XML object that represent XML comments.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -153,6 +162,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function contains(value)</b> returns the result of comparing this XML object with the given value.
+	 *
 	 * @returns the result of comparing this XML object with the given value. This treatment intentionally blurs the distinction between a single XML object and an XMLList containing only one value.
 	 * @param value XML object to test.
 	 * @memberOf XML
@@ -163,6 +173,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function contains(value)</b> returns the result of comparing this XML object with the given value.
+	 *
 	 * @returns the result of comparing this XML object with the given value. This treatment intentionally blurs the distinction between a single XML object and an XMLList containing only one value.
 	 * @param value XMLList object to test.
 	 * @memberOf XML
@@ -173,6 +184,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function copy()</b> returns a deep copy of the XML object.
+	 *
 	 * @returns the copy method returns a deep copy of this XML object with the internal [[Parent]] property set to <b>null</b>.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -182,6 +194,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function descendants(name)</b> returns all the XML valued descendants (children, grandchildren, great-grandchildren, etc.)
+	 *
 	 * @returns all the XML valued descendants (children, grandchildren, great-grandchildren, etc.) of this XML object with the given name. If the name parameter is omitted, it returns all descendants of this XML object.
 	 * @param name optional parameter to identity the decendants. If omitted all decendants are returned.
 	 * @memberOf XML
@@ -192,6 +205,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function elements(name)</b> returns the child elements.
+	 *
 	 * @returns an XMLList containing all the children of this XML object that are XML elements with the given name. When the elements method is called with no parameters, it returns an XMLList containing all the children of this XML object that are XML elements regardless of their name.
 	 * @param name optional parameter to identity the element. If omitted all children are returned.
 	 * @memberOf XML
@@ -202,6 +216,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function hasComplexContent()</b> a Boolean value indicating whether this XML object contains complex content.
+	 *
 	 * @returns a Boolean value indicating whether this XML object contains complex content. An XML object is considered to contain complex content if it represents an XML element that has child elements. XML objects representing attributes, comments, processing instructions and text nodes do not have complex content.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -211,6 +226,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function hasSimpleContent()</b> a Boolean value indicating whether this XML object contains simple content.
+	 *
 	 * @returns a Boolean value indicating whether this XML object contains simple content. An XML object is considered to contain simple content if it represents a text node, represents an attribute node or if it represents an XML element that has no child elements. XML objects representing comments and processing instructions do not have simple content.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -220,6 +236,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function inScopeNamespaces()</b> returns an array of Namespace objects representing the namespaces in scope for this object.
+	 *
 	 * @returns an array of Namespace objects representing the namespaces in scope for this object.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -229,6 +246,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function insertChildAfter( child1 , child2)</b> inserts the given {@code child2} after the given {@code child1} in this XML object and returns this XML object. If {@code child1} is <b><i>null</i></b>, the insertChildAfter method inserts {@code child2} before all children of this XML object (i.e., after none of them). If {@code child1} does not exist in this XML object, it returns without modifying this XML object.
+	 *
 	 * @returns XML object representing <b><i>x</i></b>.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -248,6 +266,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function length()</b> the length method always returns the integer 1 for XML objects.
+	 *
 	 * @returns 1 for XML objects (allowing an XML object to be treated like an XML List with a single item.)
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -257,6 +276,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function localName()</b> returns the localName part of the XML object.
+	 *
 	 * @returns the local name of this object.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -266,6 +286,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function name()</b> returns qualified name for the XML object.
+	 *
 	 * @returns the qualified name associated with this XML object.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -275,6 +296,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function namespace(prefix)</b> returns the namespace associated with this object.
+	 *
 	 * @param prefix optional prefix identifier
 	 * @returns the namespace associated with this object, or if a prefix is specified, an in-scope namespace with that prefix.
 	 * @memberOf XML
@@ -285,6 +307,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function namespaceDeclarations()</b> returns a string representing the kind of object this is (e.g. "element").
+	 *
 	 * @returns an Array of Namespace objects representing the namespace declarations associated with this XML object in the context of its parent.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -294,6 +317,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function nodeKind()</b> return an array of Namespace objects representing the namespace declarations associated with this object.
+	 *
 	 * @returns a string representing the <b><i>Class</i></b> of this XML object
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -303,6 +327,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function normalize()</b> puts all text nodes in this and all descendant XML objects into a normal form by merging adjacent text nodes and eliminating empty text nodes.
+	 *
 	 * @returns this XML object
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -318,6 +343,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Get the parent element of the second name in "e". Returns {@code <employee id="1" ...}
 	 * var firstNameParent = e..name[1].parent();
 	 * </pre>
+	 *
 	 * @returns the parent of this XML object
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -327,6 +353,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function processingInstructions(name)</b> A list of all processing instructions that are children of this element.
+	 *
 	 * @param name optional node name filter.
 	 * @returns an XMLList containing all the children of this XML object that are processing-instructions with the given <b><i>name</i></b>. When the processingInstructions method is called with no parameters, it returns an XMLList containing all the children of this XML object that are processing-instructions regardless of their name.
 	 * @memberOf XML
@@ -343,6 +370,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Add a new child element to the front of John's employee element
 	 * e.employee.(name == "John").prependChild({@code <prefix>Mr.</prefix>});
 	 * </pre>
+	 *
 	 * @returns this XML object
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -352,6 +380,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function removeNamespace(namespace)</b> removes a namespace from the in-scope namespaces of the element.
+	 *
 	 * @param namespace to remove
 	 * @returns a copy of this XML object.
 	 * @memberOf XML
@@ -370,6 +399,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Replace all item elements in the order with a single empty item
 	 * order.replace("item", <item/>);}
 	 * </pre>
+	 *
 	 * @param propertyName name of property to replace.
 	 * @param value XML, XMLList or any other object (that can be converted using ToString()) to insert.
 	 * @returns this XML object
@@ -389,6 +419,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * // Replace all item elements in the order with a single empty item
 	 * order.replace("item", <item/>);}
 	 * </pre>
+	 *
 	 * @param propertyName number index to replace.
 	 * @param value XML, XMLList or any other object (that can be converted using ToString()) to insert.
 	 * @returns this XML object
@@ -407,6 +438,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * employees.replace(0, <requisition status="open"/>);
 	 * e.employee.(name == "Jim").setChildren(<name>John</name> + <age>35</age>);}
 	 * </pre>
+	 *
 	 * @param value new XML to set.
 	 * @returns this XML object
 	 * @memberOf XML
@@ -424,6 +456,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 	 * employees.replace(0, <requisition status="open"/>);
 	 * e.employee.(name == "Jim").setChildren(<name>John</name> + <age>35</age>);}
 	 * </pre>
+	 *
 	 * @param value new XMLList to set.
 	 * @returns this XML object
 	 * @memberOf XML
@@ -434,6 +467,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function setLocalName(name)</b> replaces the local name of this XML object with a string constructed from the given <b><i>name</i></b>.
+	 *
 	 * @param name to set for the XML element.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -443,6 +477,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function setName(name)</b> sets the name of the XML object to the requested value (possibly qualified).
+	 *
 	 * @param name qualified name to set.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -452,6 +487,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function setNamespace(namespace)</b> sets the namespace of the XML object to the requested value.
+	 *
 	 * @param namespace to set.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -461,6 +497,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function text()</b> returns an XMLList containing all XML properties of this XML object that represent XML text nodes.
+	 *
 	 * @return concatenation of all text node children as a list.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML
@@ -470,6 +507,7 @@ public interface E4XXMLFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function toXMLString()</b> returns the toXMLString() method returns an XML encoded string representation of this XML object. Unlike the toString method, toXMLString provides no special treatment for XML objects that contain only XML text nodes (i.e., primitive values). The toXMLString method always includes the start tag, attributes and end tag of the XML object regardless of its content. It is provided for cases when the default XML to string conversion rules are not desired.
+	 *
 	 * @return Serializes this XML object as parseable XML.
 	 * @memberOf XML
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XML

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XXMLListFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/e4x/functions/E4XXMLListFunctions.java
@@ -12,6 +12,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function attribute(attributeName)</b> calls the attribute method of each XML object in this XMLList object passing attributeName as a parameter and returns an XMLList containing the results in order.
+	 *
 	 * @param attributeName name of attribute to find.
 	 * @returns an XMLList containing the results in order
 	 * @memberOf XMLList
@@ -23,6 +24,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function attributes()</b> calls the attributes() method of each XML object in this XMLList object and returns an XMLList containing the results in order.
+	 *
 	 * @returns an XMLList containing the results in order.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -33,6 +35,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function child(propertyName)</b> calls the child() method of each XML object in this XMLList object and returns an XMLList containing the results in order.
+	 *
 	 * @param propertyName name of XML element to find.
 	 * @returns an XMLList containing the results in order.
 	 * @memberOf XMLList
@@ -53,6 +56,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 	 * // get all grandchildren of the order that have the name price
 	 * var grandChildren = order.children().price;
 	 * </pre>
+	 *
 	 * @returns an XMLList containing the results concatenated in order.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXML XMLList
@@ -63,6 +67,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function comments()</b> calls the comments method of each XML object in this XMLList object and returns an XMLList containing the results concatenated in order.
+	 *
 	 * @returns an XMLList containing the results concatenated in order.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -73,6 +78,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function contains(value)</b> returns a boolean value indicating whether this XMLList object contains an XML object that compares equal to the given <b><i>value</i></b>.
+	 *
 	 * @returns <b><i>true</i></b> if XMLList contains XML <b><i>value</i></b>, otherwise <b><i>false</i></b>.
 	 * @param value XML object to test.
 	 * @memberOf XMLList
@@ -83,6 +89,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function copy()</b> returns a deep copy of the XMLList object.
+	 *
 	 * @returns the copy method returns a deep copy of this XMLList object..
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -92,6 +99,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function descendants(name)</b> calls the descendants method of each XML object in this XMLList object with the optional parameter name (or the string "*" if name is omitted) and returns an XMLList containing the results concatenated in order.
+	 *
 	 * @returns all the XML valued descendants (children, grandchildren, great-grandchildren, etc.) of this XMLList object with the given name. If the name parameter is omitted, it returns all descendants of this XMLList object.
 	 * @param name optional parameter to identity the descendants. If omitted all descendants are returned.
 	 * @memberOf XMLList
@@ -103,6 +111,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function elements(name)</b> calls the elements method of each XML object in this XMLList object passing the optional parameter name (or "*" if it is omitted) and returns an XMList containing the results in order.
+	 *
 	 * @returns an XMLList containing all the children of this XMLList object that are XML elements with the given name. When the elements method is called with no parameters, it returns an XMLList containing all the children of this XML object that are XML elements regardless of their name.
 	 * @param name optional parameter to identity the element. If omitted all children are returned.
 	 * @memberOf XMLList
@@ -114,6 +123,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function hasComplexContent()</b> returns a Boolean value indicating whether this XMLList object contains complex content. An XMLList object is considered to contain complex content if it is not empty, contains a single XML item with complex content or contains elements.
+	 *
 	 * @returns <b><i>true</i></b> if XMLList contains complex content, otherwise <b><i>false</i></b>.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -123,6 +133,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function hasSimpleContent()</b> returns a Boolean value indicating whether this XMLList contains simple content. An XMLList object is considered to contain simple content if it is empty, contains a single XML item with simple content or contains no elements.
+	 *
 	 * @returns <b><i>true</i></b> if XMLList contains simple content, otherwise <b><i>false</i></b>.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -139,6 +150,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 	 *   print("Employee name:" + e..name[i]);
 	 * }
 	 * </pre>
+	 *
 	 * @returns the number of properties in this XMLList object.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -148,6 +160,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function normalize()</b> puts all text nodes in this XMLList, all the XML objects it contains and the descendents of all the XML objects it contains into a normal form by merging adjacent text nodes and eliminating empty text nodes.
+	 *
 	 * @returns this XMLList object
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -157,6 +170,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function parent()</b> If all items in this XMLList object have the same parent, it is returned. Otherwise, the parent method returns <b><i>undefined</i></b>.
+	 *
 	 * @returns the parent of this XMLList object
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -166,6 +180,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function processingInstructions(name)</b> calls the processingInstructions method of each XML object in this XMLList object passing the optional parameter name (or "*" if it is omitted) and returns an XMList containing the results in order.
+	 *
 	 * @param name optional node name filter.
 	 * @returns an XMList containing the results in order.
 	 * @memberOf XMLList
@@ -177,6 +192,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function text()</b> calls the text method of each XML object contained in this XMLList object and returns an XMLList containing the results concatenated in order.
+	 *
 	 * @return an XMLList containing the results concatenated in order.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList
@@ -187,6 +203,7 @@ public interface E4XXMLListFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function toXMLString()</b> returns the toXMLString() method returns an XML encoded string representation of this XML object. Unlike the toString method, toXMLString provides no special treatment for XML objects that contain only XML text nodes (i.e., primitive values). The toXMLString method always includes the start tag, attributes and end tag of the XML object regardless of its content. It is provided for cases when the default XML to string conversion rules are not desired.
+	 *
 	 * @return Serializes this XML object as parseable XML.
 	 * @memberOf XMLList
 	 * @see org.fife.rsta.ac.js.ecma.api.e4x.E4XXMLList XMLList

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSArray.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSArray.java
@@ -3,7 +3,8 @@ package org.fife.rsta.ac.js.ecma.api.ecma3;
 import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSArrayFunctions;
 
 /**
- * Object Array
+ * Object Array.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSArray implements JSArrayFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSBoolean.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSBoolean.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSObjectFunctions;
 
 
 /**
- * Object Boolean
+ * Object Boolean.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSBoolean implements JSObjectFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSDate.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSDate.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSDateFunctions;
 
 
 /**
- * Object Date
+ * Object Date.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSDate implements JSDateFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSError.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSError.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSObjectFunctions;
 
 
 /**
- * Object Error
+ * Object Error.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSError implements JSObjectFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSFunction.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSFunction.java
@@ -4,13 +4,15 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSFunctionFunctions;
 
 
 /**
- * Object Function
+ * Object Function.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSFunction implements JSFunctionFunctions {
 
     /**
-     * Object Function(argument_names..., body)
+     * Object Function(argument_names..., body).
+	 *
      * @constructor
      * @extends Object
      * @param argumentNames Any number of string arguments, each naming one or more arguments of the Function object to be created.

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSMath.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSMath.java
@@ -2,7 +2,8 @@ package org.fife.rsta.ac.js.ecma.api.ecma3;
 
 
 /**
- * Object Math
+ * Object Math.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSMath {
@@ -173,6 +174,7 @@ public abstract class JSMath {
 	 * c = Math.ceil(1.0) //returns 1.0
 	 * d = Math.ceil(-1.99); //returns -1.0
 	 * </pre>
+	*
      * @memberOf Math
      * @param x any number or numeric value.
      * @type Number
@@ -225,6 +227,7 @@ public abstract class JSMath {
 	 * c = Math.floor(1.0) //returns 1.0
 	 * d = Math.floor(-1.99); //returns -2.0
 	 * </pre>
+	*
      * @memberOf Math
      * @param x any number or numeric value.
      * @type Number

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSNumber.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSNumber.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSNumberFunctions;
 
 
 /**
- * Object Number
+ * Object Number.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSNumber implements JSNumberFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSObject.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSObject.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSObjectFunctions;
 
 
 /**
- * Base JavaScript Object
+ * Base JavaScript Object.
+ *
  * @since Standard ECMA-262 3rd. Edition
  *
  */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSRegExp.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSRegExp.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSRegExpFunctions;
 
 
 /**
- * Object RegExp
+ * Object RegExp.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSRegExp implements JSRegExpFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSString.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSString.java
@@ -4,7 +4,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.functions.JSStringFunctions;
 
 
 /**
- * Object String
+ * Object String.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSString implements JSStringFunctions {
@@ -62,6 +63,7 @@ public abstract class JSString implements JSStringFunctions {
 	 * <pre>
      * var s = String.fromCharCode(104,101,108,108,111); //returns the string hello
 	 * </pre>
+	 *
      * @memberOf String
      * @param charCode Zero or more integers that specify Unicode encodings of the characters in the string to be created.
      * @returns A new string containing characters with the specified encoding.

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSUndefined.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/JSUndefined.java
@@ -2,7 +2,8 @@ package org.fife.rsta.ac.js.ecma.api.ecma3;
 
 
 /**
- * Object Undefined
+ * Object Undefined.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JSUndefined {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSArrayFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSArrayFunctions.java
@@ -59,6 +59,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * stack.pop(); // returns 2,  stack [1]
 	 * stack.pop(); // returns 1,  stack []
 	 * </pre>
+	 *
 	 * @returns The last element of the <b>array</b>.
 	 * @memberOf Array
 	 * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSArray Array
@@ -77,6 +78,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * var vals = [];
 	 * vals.push(1,2,3); // returns new array [1,2,3]
 	 * </pre>
+	 *
 	 * @param array One or more values to be appended to the end of the <b>array</b>.
 	 * @memberOf Array
 	 * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSArray Array
@@ -95,6 +97,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * var r = [1,2,3];
 	 * r.reverse(); // r is now [3,2,1]
 	 * </pre>
+	 *
 	 * @returns The <b>array</b> after it has been reversed.
 	 * @memberOf Array
 	 * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSArray Array
@@ -113,6 +116,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * s.shift(); // Returns 1; s = [2,3]
 	 * s.shift(); // Returns 2; s = [3]
 	 * </pre>
+	 *
 	 * @returns The former first element of the <b>array</b>
 	 * @memberOf Array
 	 * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSArray Array
@@ -134,6 +138,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * s.slice(3); // Returns [4,5]
 	 * s.slice(1,-1); // Returns [2,3,4]
 	 * </pre>
+	 *
 	 * @param start The array index from where to begin.  If negative, this argument specifies a position measured from the end of the array.
 	 * @param end The array index immediately after the end of the slice. If not specified then the slice includes all the array elements from the start to the end of the array.
 	 * @returns A new <b>array</b> containing elements from the {@code start} up to, but not including the <b><i>end</i></b> of the slice.
@@ -156,6 +161,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * s.sort(); //Alphabetical order : 1111,22,33,4,55
 	 * s.sort(numbersort); //Numerical order : 4, 22, 33, 55, 1111
 	 * </pre>
+	 *
 	 * @param function an optional function used to specify the sorting order
 	 * @returns A reference to the <b>array</b>
 	 * @memberOf Array
@@ -176,6 +182,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * s.splice(1,1); //Returns [4]; s is [1]
 	 * s.splice(1,0,2,3); //Returns []; s is [1 2 3]
 	 * </pre>
+	 *
 	 * @param start the <b>array</b> element at which the insertion and/or deletion is to begin
 	 * @param deletecount The number of elements starting with and including <i><b>start</b></i>.
 	 * @param items zero or more items to be inserted into the <b>array</b>
@@ -199,6 +206,7 @@ public interface JSArrayFunctions extends JSObjectFunctions {
 	 * s.unshift(22); //Returns 3; s is [22,1,2]
 	 * s.shift(); //Returns 22; s is [1,2]
 	 * </pre>
+	 *
 	 * @param value One or more values to insert at the beginning of the <b>array</b>
 	 * @returns The new length of the array
 	 * @memberOf Array

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSFunctionFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSFunctionFunctions.java
@@ -15,6 +15,7 @@ public interface JSFunctionFunctions extends JSObjectFunctions {
 	 * //overrides it with its own version of the method
 	 * Object.prototype.toString().apply(o);
 	 * </pre>
+	 *
      * @param thisObject The object to which the <b><i>function</i></b> is applied.
      * @param argArray An array of arguments to be passed to <b><i>function</i></b>
      * @return Whatever value is returned by <b><i>function</i></b>
@@ -33,6 +34,7 @@ public interface JSFunctionFunctions extends JSObjectFunctions {
 	 * //overrides it with its own version of the method
 	 * Object.prototype.toString().call(o);
 	 * </pre>
+	 *
      *  @param thisObject The object to which the <b><i>function</i></b> is applied.
      *  @param args An array of arguments to be passed to <b><i>function</i></b>
      *  @return Whatever value is returned by <b><i>function</i></b>

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSGlobalFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSGlobalFunctions.java
@@ -11,6 +11,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function decodeURI(uri)</b> unescape characters in a URI.
+	 *
 	 * @param uri A string that contains an encoded URI or other text to be decoded.
 	 * @returns A copy of <b><i>uri</i></b>, with any hexidecimal escaped sequences replaced with characters they represent.
 	 * @memberOf Global
@@ -27,6 +28,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function decodeURIComponent(s)</b> unescape characters in a URI component.
+	 *
 	 * @param s A string that contains an encoded URI components or other text to be decoded.
 	 * @returns A copy of <b><i>s</i></b>, with any hexidecimal escaped sequences replaced with characters they represent.
 	 * @memberOf Global
@@ -44,6 +46,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function encodeURI(uri)</b> escape characters in a URI.
+	 *
 	 * @param uri A string that contains the URI or other text to be encoded.
 	 * @returns A copy of <b><i>uri</i></b>, with certain characters replaced by hexidecimal escape sequences.
 	 * @memberOf Global
@@ -60,6 +63,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function encodeURIComponent(s)</b> escape characters in a URI Component.
+	 *
 	 * @param s A string that contains a portion of a URI or other text to be encoded.
 	 * @returns A copy of <b><i>s</i></b>, with certain characters replaced by hexidecimal escape sequences.
 	 * @memberOf Global
@@ -76,6 +80,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function escape(s)</b> encode a string.
+	 *
 	 * @param s A string to be "escaped" or encoded.
 	 * @returns An encoded copy of <b><i>s</i></b>, with certain characters replaced by hexidecimal escape sequences.
 	 * @memberOf Global
@@ -94,6 +99,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 	 * <pre>
 	 * eval("2+5"); //Returns 7
 	 * </pre>
+	 *
 	 * @param code A string that contains the JavaScript expression to be evaluated or the statements to be executed.
 	 * @returns The value of the evaluated <b><i>code</i></b>, if any.
 	 * @memberOf Global
@@ -105,6 +111,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function isFinite(n)</b> determine whether a number is finite.
+	 *
 	 * @param n The number to be tested.
 	 * @returns <b><i>true</i></b> if <b><i>n</i></b> is or can be converted to a finite number or otherwise <b><i>false</i></b> if <b><i>n</i></b> is NaN or positive or negative Infinity.
 	 * @memberOf Global
@@ -130,6 +137,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 	 * isNaN(true); //=&gt; false
 	 * isNaN(undefined); //=&gt; true
 	 * </pre>
+	 *
 	 * @param n The number to be tested.
 	 * @returns <b><i>true</i></b> if <b><i>n</i></b> is not a number or if it is the special numeric value NaN, otherwise <b><i>false</i></b> if <b><i>n</i></b> is any other number.
 	 * @memberOf Global
@@ -145,6 +153,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function parseFloat(s)</b> convert a string to a number.
+	 *
 	 * @param s The string to be parsed and converted to a number
 	 * @returns The parsed number or <b><i>NaN</i></b> if <b><i>s</i></b> does not begin with a valid number.
 	 * @memberOf Global
@@ -158,6 +167,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function parseInt(s, radix)</b> convert a string to an integer.
+	 *
 	 * @param s The string to be parsed and converted to an integer
 	 * @param radix An optional integer argument that represents the radix (i.e. base) of the number to be parsed. If omitted or 0, the number is parsed in base 10.
 	 * @returns The parsed number or <b><i>NaN</i></b> if <b><i>s</i></b> does not begin with a valid number.
@@ -172,6 +182,7 @@ public interface JSGlobalFunctions extends JSObjectFunctions {
 
 	/**
 	 * <b>function unescape(s)</b> decode an escaped string.
+	 *
 	 * @param s A string to be "unescaped" or decoded.
 	 * @returns A decoded copy of <b><i>s</i></b>.
 	 * @memberOf Global

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSNumberFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSNumberFunctions.java
@@ -17,6 +17,7 @@ public interface JSNumberFunctions extends JSObjectFunctions {
 	 * n.toFixed(6); //returns 12345.678900: note zeros
 	 * (1.23e+20).toFixed(2); //returns 123000000000000000000.00
 	 * </pre>
+	 *
      * @memberOf Number
      * @param fractionDigits The number of digits to appear after the decimal point. If omitted it is treated as 0.
      * @returns A string representation of <b><i>number</i></b> that does not use exponential notation and has exactly the digits applied.
@@ -37,6 +38,7 @@ public interface JSNumberFunctions extends JSObjectFunctions {
 	 * n.toExponential(10); //returns 1.2345678900e+4
 	 * n.toExponential(); //returns 1.23456789e+4
 	 * </pre>
+	 *
      * @memberOf Number
      * @param fractionDigits The number of digits that appear after the decimal point.
      * @returns a string representation of <b><i>number</i></b> in exponential notation.
@@ -57,6 +59,7 @@ public interface JSNumberFunctions extends JSObjectFunctions {
 	 * n.toPrecision(5); //returns 12346
 	 * n.toPrecision(10); //returns 12345.67890
 	 * </pre>
+	 *
      * @memberOf Number
      * @param fractionDigits The number of significant digits to appear in the returned string.
      * @returns a string representation of <b><i>number</i></b> that contains the number significant digits.

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSObjectFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSObjectFunctions.java
@@ -10,6 +10,7 @@ public interface JSObjectFunctions {
 
     /**
      * <b>function toString()</b> define an objects string representation.
+	 *
      * @memberOf Object
      * @returns a string representing the object
      * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSObject Object
@@ -23,6 +24,7 @@ public interface JSObjectFunctions {
 
     /**
      * <b>function toLocaleString()</b> return an object localized string representation.
+	 *
      * @memberOf Object
      * @returns A string representing the object
      * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSObject Object
@@ -34,6 +36,7 @@ public interface JSObjectFunctions {
 
     /**
      * <b>function valueOf()</b> the primitive value of a specified object.
+	 *
      * @memberOf Object
      * @returns The primitive value associated with the <b><i>object</i></b>, if any.
      * @see org.fife.rsta.ac.js.ecma.api.ecma3.JSObject Object.
@@ -54,6 +57,7 @@ public interface JSObjectFunctions {
 	 * o.hasOwnProperty("y"); //return false; o does not have property y.
 	 * o.hasOwnProperty("toString"); //return false; o inherits toString.
 	 * </pre>
+	 *
      * @memberOf Object
      * @param name A string that contains the name of a property of <b><i>object</i></b>.
      * @returns <b><i>true</i></b> if <b><i>object</i></b> has a noninherited property with the name specified by <b><i>name</i></b>.
@@ -76,6 +80,7 @@ public interface JSObjectFunctions {
 	 * Function.prototype.isPrototypeOf(o.toString(); //return true: toString is a function.
 	 * Array.prototype.isPrototypeOf([1,2,3]; //return true: [1,2,3] is an Array.
 	 * </pre>
+	 *
      * @memberOf Object
      * @param o Any object
      * @returns <b><i>true</i></b> if <b><i>object</i></b> is prototype of o. <b><i>false</i></b> is not an object or if <b><i>object</i></b>
@@ -97,6 +102,7 @@ public interface JSObjectFunctions {
 	 * o.propertyIsEnumerable("y"); //return false; o does not have property y.
 	 * o.propertyIsEnumerable("toString"); //return false; o inherits toString.
 	 * </pre>
+	 *
      * @memberOf Object
      * @param name A string that contains the name of a property of <b><i>object</i></b>.
      * @returns <b><i>true</i></b> if <b><i>object</i></b> has a noninherited property with the name specified by <b><i>name</i></b> and

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSRegExpFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSRegExpFunctions.java
@@ -18,6 +18,7 @@ public interface JSRegExpFunctions extends JSObjectFunctions {
 	 *   alert("Matched: " + result[0]);
 	 * }
 	 * </pre>
+	 *
 	 * @param string The string to be searched
 	 * @returns An array containing results on the match or <b><i>null</i></b> if no match is found.
 	 * @type Array
@@ -39,6 +40,7 @@ public interface JSRegExpFunctions extends JSObjectFunctions {
 	 * r.test("JavaScript"); //returns true
 	 * r.test("ECMAScript"); //returns false
 	 * </pre>
+	 *
 	 * @param string The string to be tested
 	 * @returns <b><i>true</i></b> if <b><i>string</i></b> contains text that matches <b><i>regexp</i></b>, otherwise <b><i>false</i></b>.
 	 * @type Boolean

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSStringFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma3/functions/JSStringFunctions.java
@@ -84,6 +84,7 @@ public interface JSStringFunctions extends JSObjectFunctions {
 	 * var string;//array of string initialised somewhere
 	 * strings.sort(function(a,b){return a.localCompare(b);});
 	 * </pre>
+	 *
      * @memberOf String
      * @param otherString A <b><i>string</i></b> to be compared, in a locale-sensitive fashion, with <b><i>string</i></b>.
      * @returns A number that indicates the result of the comparison.
@@ -142,6 +143,7 @@ public interface JSStringFunctions extends JSObjectFunctions {
 	 * s.slice(3, -1); //returns "def"
 	 * s.slice(3,-2); //returns "de"
 	 * </pre>
+	 *
      * @memberOf String
      * @param start The start index where the slice if to begin.
      * @param end Optional end index where the slice is to end.
@@ -160,6 +162,7 @@ public interface JSStringFunctions extends JSObjectFunctions {
      * "1|2|3|4".split("|"); //returns ["1","2","3","4"]
 	 * "%1%2%3%4%".split("%"); //returns ["","1","2","3","4",""]
 	 * </pre>
+	 *
      * @memberOf String
      * @param separator The string or regular expression at which the <b><i>string</i></b> splits
      * @param limit Optional value that specifies the maximum length of the returned array.

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Array.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Array.java
@@ -8,7 +8,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5ArrayFunctions;
 
 
 /**
- * Object Array
+ * Object Array.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JS5Array extends JSArray implements JS5ArrayFunctions {
@@ -44,6 +45,7 @@ public abstract class JS5Array extends JSArray implements JS5ArrayFunctions {
 	 * @constructor
 	 * @extends Object
 	 * @param element0  An argument list of two or more values. The <b>length</b> field set to the number of arguments.
+	 * @param elementn The nth argument.
 	 * @since Standard ECMA-262 3rd. Edition
 	 * @since Level 2 Document Object Model Core Definition.
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Date.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Date.java
@@ -6,7 +6,8 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.JSString;
 import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5DateFunctions;
 
 /**
- * Object Boolean
+ * Object Date.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JS5Date extends JSDate implements JS5DateFunctions {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Function.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Function.java
@@ -5,13 +5,15 @@ import org.fife.rsta.ac.js.ecma.api.ecma3.JSString;
 import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5FunctionFunctions;
 
 /**
- * Object Function
+ * Object Function.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JS5Function extends JSFunction implements JS5FunctionFunctions {
 
 	/**
-     * Object Function(argument_names..., body)
+     * Object Function(argument_names..., body).
+	 *
      * @constructor
      * @extends Object
      * @param argumentNames Any number of string arguments, each naming one or more arguments of the Function object to be created.

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5JSON.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5JSON.java
@@ -1,7 +1,8 @@
 package org.fife.rsta.ac.js.ecma.api.ecma5;
 
 /**
- * Object JSON
+ * Object JSON.
+ *
  * @since Standard ECMA-262 5th. Edition
  */
 public abstract class JS5JSON  {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Object.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5Object.java
@@ -6,13 +6,14 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5ObjectFunctions;
 
 
 /**
- * Base JavaScript Object
+ * Base JavaScript Object.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 
 	/**
-     * Object Object()
+     * Object Object().
      *
      * <p>Creates a new object instance</p>
      *
@@ -24,7 +25,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
     }
 
     /**
-     * Object Object(value)
+     * Object Object(value).
      *
      *
      * @constructor
@@ -45,6 +46,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 *   y: { value: 2, writable, false, enumerable:true. configurable:true},
 	 * });
 	 * </pre>
+	 *
      * @param proto The prototype of the newly created object, or null.
      * @param descriptors An optional object that maps property names to property descriptors.
      * @returns A newly created object that inherits from {@code proto} and has properties described by <b><i>descriptors</i></b>
@@ -70,6 +72,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 *   y: { value: 2, writable, false, enumerable:true. configurable:true},
 	 * });
 	 * </pre>
+	 *
      * @param o The object on which properties are to be created or configured.
      * @param descriptors An object that maps property names to property descriptors.
      * @returns The object {@code o}
@@ -93,6 +96,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 *   Object.defineProperty (o, n, { value: v, writable, false, enumerable:true. configurable:true});
 	 * }
 	 * </pre>
+	 *
      * @param o The object on which a property is to be created or configured.
      * @param name The name of the property created or configured.
      * @param desc A property descriptor object that describes the new property.
@@ -144,6 +148,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 * <pre>
 	 * Object.getOwnPropertyNames([]); //returns [length]: "length" is non enumerable
 	 * </pre>
+	 *
      * @param o An object
      * @returns An array that contains the names of all non-inherited properties of {@code o}, including non-enumerable properties.
      * @see  org.fife.rsta.ac.js.ecma.api.ecma5.JS5Object Object
@@ -165,6 +170,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 * var o = Object.create(p); //an object inherited from p
 	 * Object.getPrototypeOf(o); //=&gt; p
 	 * </pre>
+	 *
      * @param o An object.
      * @returns The prototype of object {@code o}.
      * @see  org.fife.rsta.ac.js.ecma.api.ecma5.JS5Object Object
@@ -186,6 +192,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 * Object.preventExtensions(o); //Make it non-extensible
 	 * Object.isExtensible(o); //=&gt; false
 	 * </pre>
+	 *
      * @param o The object to be checked for extensibility
      * @returns {code true} if the object can be extended with new properties, otherwise {code false}.
      * @see  org.fife.rsta.ac.js.ecma.api.ecma5.JS5Object Object
@@ -241,6 +248,7 @@ public abstract class JS5Object extends JSObject implements JS5ObjectFunctions {
 	 * <pre>
 	 * Object.keys({x:1, y:2}); // =&gt; ["x", "y"]
 	 * </pre>
+	 *
      * @param o an object
      * @returns An array that contains the names of all enumerable own (non-inherited) properties of {@code o}.
      * @see  org.fife.rsta.ac.js.ecma.api.ecma5.JS5Object Object

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5String.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/JS5String.java
@@ -5,14 +5,15 @@ import org.fife.rsta.ac.js.ecma.api.ecma5.functions.JS5StringFunctions;
 
 
 /**
- * Object String
+ * Object String.
+ *
  * @since Standard ECMA-262 3rd. Edition
  */
 public abstract class JS5String extends JSString implements JS5StringFunctions {
 
 
 	/**
-     * Object String(s)
+     * Object String(s).
      *
      * @constructor
      * @extends Object

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/functions/JS5ArrayFunctions.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ecma/api/ecma5/functions/JS5ArrayFunctions.java
@@ -19,6 +19,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * [1,2,3].every(function(x){return x &lt; 2;} //=&gt;false
 	 * [].every(function(x){return false;} //=&gt;true, always true for []
 	 * </pre>
+	 *
 	 * @param predicate A predicate function to test array elements
 	 * @param o The optional <b><i>this</i></b> value for invocations of <b><i>predicate</i></b>.
 	 * @returns <b><i>true</i></b> if <b><i>predicate</i></b> is true for every element of the <b>array</b> or <b><i>false</i></b>
@@ -39,6 +40,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * <pre>
 	 * [1,2,3].filter(function(x){return x &gt; 1}); // returns [2,3]
 	 * </pre>
+	 *
 	 * @param predicate The function to invoke to determine whether an element of <b>array</b> will be included in the returned array.
 	 * @param o An optional value on which <b><i>predicate</i></b> is invoked
 	 * @returns a new <b>array</b> containing only those elements of <b>array</b> for which <b><i>predicate</i></b> returned <b><i>true</i></b>
@@ -62,6 +64,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * var a = [1,2,3];
 	 * a.forEach(function(x,i,a){a[i]++;}); //a is now [2,3,4]
 	 * </pre>
+	 *
 	 * @param f The function to invoke for each element of <b>array</b>
 	 * @param o An optional value on which {@code f} is invoked
 	 * @memberOf Array
@@ -80,6 +83,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * ['a','b','c'].indexOf('d'); //returns -1
 	 * ['a','b','c'].indexOf('a',1); //returns -1
 	 * </pre>
+	 *
 	 * @param value The value to search <b>array</b> for.
 	 * @param start An optional array index at which to begin the search. If omitted, 0 is used.
 	 * @returns The <i>lowest</i> index => start of <b>array</b> at which the element matches <b><i>value</i></b>. Or -1 if no match is found
@@ -112,6 +116,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * <pre>
 	 * [1,2,3].map(function(x){return x*x;}); //returns [1,4,9]
 	 * </pre>
+	 *
 	 * @param f The function to invoke for each element of <b>array</b>. Its return becomes the elements of the returned array
 	 * @param o An optional value of which <b><i>f</i></b> is invoked
 	 * @returns A new array with elements computed by function <b><i>f</i></b>
@@ -132,6 +137,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * <pre>
 	 * [1,2,3].reduce(function(x,y){return x*y;}); //returns 6 ((1*2(*3))
 	 * </pre>
+	 *
 	 * @param f A function that combines two values and returns a "reduced" value
 	 * @param initial An optional initial value to see the array reduction with.
 	 * @returns The reduced value of an array.
@@ -152,6 +158,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * <pre>
 	 * [2,10,60].reduceRight(function(x,y){return x/y;}); //returns 3 (60/10)/2
 	 * </pre>
+	 *
 	 * @param f A function that combines two values and returns a "reduced" value
 	 * @param initial An optional initial value to see the array reduction with.
 	 * @returns The reduced value of an array.
@@ -172,6 +179,7 @@ public interface JS5ArrayFunctions extends JS5ObjectFunctions, JSArrayFunctions 
 	 * [1,2,3].some(function(x){return x &gt; 2;} //=&gt;true
 	 * [].some(function(x){return true;} //=&gt;false, always false for []
 	 * </pre>
+	 *
 	 * @param predicate A predicate function to test array elements.
 	 * @param o The optional <b><i>this</i></b> value for the invocations of  <b><i>predicate</i></b>.
 	 * @returns <b><i>true</i></b> if <b><i>predicate</i></b> returns <b><i>true</i></b> for at least one element of <b>array</b>, otherwise <b><i>false</i></b>

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JSR223JavaScriptCompletionResolver.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JSR223JavaScriptCompletionResolver.java
@@ -21,6 +21,7 @@ public class JSR223JavaScriptCompletionResolver extends
 	 * RhinoCompletionProvider constructor
 	 * - resolves Rhino specific types
 	 * Used to resolve Static class e.g. java.lag.String methods and fields
+	 *
 	 * @param provider
 	 */
 	public JSR223JavaScriptCompletionResolver(SourceCompletionProvider provider) {
@@ -100,6 +101,7 @@ public class JSR223JavaScriptCompletionResolver extends
 
 	/**
 	 * Try to resolve the Token.NAME AstNode and return a TypeDeclaration.
+	 *
 	 * @param node node to resolve
 	 * @return TypeDeclaration if the name can be resolved as a Java Class else null
 	 */

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptCompletionResolver.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptCompletionResolver.java
@@ -82,6 +82,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 
 	/**
 	 * Resolve node type to TypeDeclaration. Called instead of #compileText(String text) when document is already parsed
+	 *
 	 * @param text The node to resolve
 	 * @return TypeDeclaration for node or null if not found.
 	 */
@@ -140,6 +141,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 	/**
 	 * Test whether the node can be resolved as a static Java class.
 	 * Only looks for Token.NAME nodes to test
+	 *
 	 * @param node node to test
 	 * @return The type declaration.
 	 */
@@ -153,6 +155,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 
 	/**
 	 * Try to resolve the Token.NAME AstNode and return a TypeDeclaration.
+	 *
 	 * @param node node to resolve
 	 * @return TypeDeclaration if the name can be resolved as a Java Class else null
 	 */
@@ -498,6 +501,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 
 	/**
 	 * Creates a new JavaScriptType based on the String type.
+	 *
 	 * @param provider SourceCompletionProvider
 	 * @param type type of JavaScript type to create e.g. java.sql.Connection
 	 * @param text Text entered from the user to resolve the node. This will be null if resolveNode(AstNode node) is called
@@ -523,6 +527,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 	 * Method called if the lastJavaScriptType is not null. i.e. has gone through one iteration at least.
 	 * Resolves TypeDeclaration for parts of a variable past the first part. e.g. "".toString() //resolve toString()
 	 * In some circumstances this is useful to resolve this. e.g. for Custom Object completions
+	 *
 	 * @param node Node to resolve
 	 * @return Type Declaration
 	 *

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptResolver.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptResolver.java
@@ -25,6 +25,7 @@ public abstract class JavaScriptResolver {
 
 	/**
 	 * Resolve node type to TypeDeclaration. Called instead of #compileText(String text) when document is already parsed
+	 *
 	 * @param node AstNode to resolve
 	 * @return TypeDeclaration for node or null if not found.
 	 */
@@ -32,6 +33,7 @@ public abstract class JavaScriptResolver {
 
 	/**
 	 * Resolve node type to TypeDeclaration. Called instead of #compileText(String text) when document is already parsed
+	 *
 	 * @param text The type of node to resolve
 	 * @return TypeDeclaration for node or null if not found.
 	 */

--- a/config/checkstyle/lsSuppressions.xml
+++ b/config/checkstyle/lsSuppressions.xml
@@ -11,7 +11,7 @@
          For now we're ignoring several issues that will take some time to address.
          TODO: Remove these issues one by one.
     -->
-    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|IllegalType|JavadocContentLocation|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|RequireEmptyLineBeforeBlockTagGroup|StaticVariableName|VisibilityModifier"/>
+    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|IllegalType|JavadocContentLocation|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
 
     <!-- Lots of blocks are empty with "TODO" comments describing future implementations -->
     <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/].*" checks="EmptyBlock"/>


### PR DESCRIPTION
Like it says on the tin. Enabling one of the checkstyle rules that was disabled in `lsSuppressions.xml` for the JS language support package, and fixing all of the related issues. This is part of the tidying up of the codebase to match RSTA standards, one step at a time.