### PR TITLE
Enable checkstyle rule JavadocContentLocation for JS support

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
@@ -423,11 +423,10 @@ case Token.EXPR_RESULT:
 
 
 	/**
+	 * Returns the index of the first {@code "("}, working backwards if there is no
+	 * matching closing bracket.
 	 *
-	 * Returns the index of the first ( working backwards if there is no
-	 * matching closing bracket
-	 *
-	 * @param text
+	 * @param text The text to search through which may be {@code null}.
 	 */
 	public static int findIndexOfFirstOpeningBracket(String text) {
 		int index = 0;

--- a/config/checkstyle/lsSuppressions.xml
+++ b/config/checkstyle/lsSuppressions.xml
@@ -11,7 +11,7 @@
          For now we're ignoring several issues that will take some time to address.
          TODO: Remove these issues one by one.
     -->
-    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|IllegalType|JavadocContentLocation|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
+    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|IllegalType|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
 
     <!-- Lots of blocks are empty with "TODO" comments describing future implementations -->
     <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/].*" checks="EmptyBlock"/>


### PR DESCRIPTION
Like it says on the tin. Enable the checkstyle rule `JavadocContentLocation` for the JS language support package. It was disabled previously but this is a baby step towards getting this library onto RSTA checkstyle standards.