### PR TITLE
Enable checkstyle rule IllegalType for JS support

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/RhinoJavaScriptTypesFactory.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/RhinoJavaScriptTypesFactory.java
@@ -22,8 +22,8 @@ import org.fife.rsta.ac.js.ast.type.TypeDeclarationFactory;
  */
 public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 
-	private LinkedHashSet<String> importClasses = new LinkedHashSet<>();
-	private LinkedHashSet<String> importPackages = new LinkedHashSet<>();
+	private Set<String> importClasses = new LinkedHashSet<>();
+	private Set<String> importPackages = new LinkedHashSet<>();
 
 	public RhinoJavaScriptTypesFactory(TypeDeclarationFactory typesFactory) {
 		super(typesFactory);
@@ -43,9 +43,9 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 		mergeImports(classes, importClasses, false);
 	}
 
-	private void mergeImports(Set<String> newImports, LinkedHashSet<String> oldImports, boolean packages) {
+	private void mergeImports(Set<String> newImports, Set<String> oldImports, boolean packages) {
 		//iterate through the old imports and check whether the import exists in new. If not then add to remove and remove all types for that package/class
-		HashSet<String> remove = new HashSet<>();
+		Set<String> remove = new HashSet<>();
 		for (String obj : oldImports) {
 			if (!newImports.contains(obj)) {
 				remove.add(obj);
@@ -55,7 +55,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 
 		//now iterate through the remove list and remove imports not needed
 		if (!remove.isEmpty()) {
-			HashSet<TypeDeclaration> removeTypes = new HashSet<>();
+			Set<TypeDeclaration> removeTypes = new HashSet<>();
 			for (String name : remove) {
 				for (TypeDeclaration dec : cachedTypes.keySet()) {
 					if ((packages && dec.getQualifiedName().startsWith(name)) || (!packages && dec.getQualifiedName().equals(name))) {
@@ -84,7 +84,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 	 * @param oldImports
 	 * @return
 	 */
-	private boolean canClearCache(Set<String> newImports, LinkedHashSet<String> oldImports) {
+	private boolean canClearCache(Set<String> newImports, Set<String> oldImports) {
 		if (newImports.size() != oldImports.size()) {
 			return true;
 		}
@@ -105,7 +105,7 @@ public class RhinoJavaScriptTypesFactory extends JSR223JavaScriptTypesFactory {
 	}
 
 	private void clearAllImportTypes() {
-		HashSet<TypeDeclaration> removeTypes = new HashSet<>();
+		Set<TypeDeclaration> removeTypes = new HashSet<>();
 		//clear all non ECMA (JavaScript types) for importPackage and importClass to work properly
         for (TypeDeclaration dec : cachedTypes.keySet()) {
             if (!typesFactory.isJavaScriptType(dec) && !dec.equals(typesFactory.getDefaultTypeDeclaration())) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/RhinoJavaScriptAstParser.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/parser/RhinoJavaScriptAstParser.java
@@ -23,8 +23,8 @@ public class RhinoJavaScriptAstParser extends JavaScriptAstParser {
 
 	public static final String PACKAGES = "Packages.";
 
-	private LinkedHashSet<String> importClasses = new LinkedHashSet<>();
-	private LinkedHashSet<String> importPackages = new LinkedHashSet<>();
+	private Set<String> importClasses = new LinkedHashSet<>();
+	private Set<String> importPackages = new LinkedHashSet<>();
 
 	public RhinoJavaScriptAstParser(SourceCompletionProvider provider, int dot,
 			TypeDeclarationOptions options) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/ecma/TypeDeclarations.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/type/ecma/TypeDeclarations.java
@@ -40,7 +40,7 @@ public abstract class TypeDeclarations {
 
 	// reverse lookup for Java types to Javascript types
 	private final Map<String, String> javascriptReverseLookup = new HashMap<>();
-	private final HashSet<JavaScriptObject> ecmaObjects = new HashSet<>();
+	private final Set<JavaScriptObject> ecmaObjects = new HashSet<>();
 
 
 	public TypeDeclarations() {

--- a/config/checkstyle/lsSuppressions.xml
+++ b/config/checkstyle/lsSuppressions.xml
@@ -11,7 +11,7 @@
          For now we're ignoring several issues that will take some time to address.
          TODO: Remove these issues one by one.
     -->
-    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|IllegalType|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
+    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|CommentsIndentation|ExplicitInitialization|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
 
     <!-- Lots of blocks are empty with "TODO" comments describing future implementations -->
     <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/].*" checks="EmptyBlock"/>


### PR DESCRIPTION
Like it says on the tin. Enable the checkstyle `IllegalType` rule for the JS language support package. It was disabled previously due to its many violations, but this is one of the baby steps towards getting this library fully onto RSTA quality standards.