### PR TITLE
Enable checkstyle ExplicitInitialization rule for JS support

### DIFF
--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/JavaScriptHelper.java
@@ -355,7 +355,7 @@ case Token.EXPR_RESULT:
 	 */
 	private static final class InfixVisitor implements NodeVisitor {
 
-		private String type = null;
+		private String type;
 		private SourceCompletionProvider provider;
 
 		private InfixVisitor(SourceCompletionProvider provider) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/SourceCompletionProvider.java
@@ -120,8 +120,8 @@ public class SourceCompletionProvider extends DefaultCompletionProvider {
 	}
 
 
-	private String lastCompletionsAtText = null;
-	private List<Completion> lastParameterizedCompletionsAt = null;
+	private String lastCompletionsAtText;
+	private List<Completion> lastParameterizedCompletionsAt;
 
 	@Override
 	public List<Completion> getCompletionsAt(JTextComponent tc, Point p) {

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptFunctionType.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/ast/jsType/JavaScriptFunctionType.java
@@ -30,12 +30,12 @@ public final class JavaScriptFunctionType {
 	public static Class<?> ShortClass = Kit.classOrNull("java.lang.Short");
 	public static Class<?> StringClass = Kit.classOrNull("java.lang.String");
 	public static Class<?> DateClass = Kit.classOrNull("java.util.Date");
-	public static Class<?> JSBooleanClass = null;
-	public static Class<?> JSStringClass = null;
-	public static Class<?> JSNumberClass = null;
-	public static Class<?> JSObjectClass = null;
-	public static Class<?> JSDateClass = null;
-	public static Class<?> JSArray = null;
+	public static Class<?> JSBooleanClass;
+	public static Class<?> JSStringClass;
+	public static Class<?> JSNumberClass;
+	public static Class<?> JSObjectClass;
+	public static Class<?> JSDateClass;
+	public static Class<?> JSArray;
 
 	private String name;
 	private List<TypeDeclaration> arguments;

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptCompletionResolver.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/resolver/JavaScriptCompletionResolver.java
@@ -43,7 +43,7 @@ public class JavaScriptCompletionResolver extends JavaScriptResolver {
 
 
 	protected JavaScriptType lastJavaScriptType;
-	protected String lastLookupName = null;
+	protected String lastLookupName;
 
 
 	/**

--- a/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/tree/JavaScriptOutlineTreeGenerator.java
+++ b/RSTALanguageSupport/src/main/java/org/fife/rsta/ac/js/tree/JavaScriptOutlineTreeGenerator.java
@@ -52,7 +52,7 @@ class JavaScriptOutlineTreeGenerator implements NodeVisitor {
 
 	private JavaScriptTreeNode curScopeTreeNode;
 
-	private Map<String, List<JavaScriptTreeNode>> prototypeAdditions = null;
+	private Map<String, List<JavaScriptTreeNode>> prototypeAdditions;
 
 
 	JavaScriptOutlineTreeGenerator(RSyntaxTextArea textArea,

--- a/config/checkstyle/lsSuppressions.xml
+++ b/config/checkstyle/lsSuppressions.xml
@@ -11,7 +11,7 @@
          For now we're ignoring several issues that will take some time to address.
          TODO: Remove these issues one by one.
     -->
-    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|ExplicitInitialization|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
+    <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/]js[\\/].*" checks="AvoidNestedBlocks|JavadocTagContinuationIndentation|JavadocMethod|JavadocPackage|JavadocStyle|LineLength|MissingJavadocMethod|MissingJavadocType|NeedBraces|NonEmptyAtclauseDescription|OperatorWrap|StaticVariableName|VisibilityModifier"/>
 
     <!-- Lots of blocks are empty with "TODO" comments describing future implementations -->
     <suppress files=".*src[\\/]main[\\/]java[\\/]org[\\/]fife[\\/]rsta[\\/]ac[\\/].*" checks="EmptyBlock"/>


### PR DESCRIPTION
Like it says on the tin. As part of bringing this project up to the RSTA library standards for checkstyle, enable the `ExplicitInitialization` rule for the JS language support package.